### PR TITLE
Remove raw types and clean some code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,5 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>librewsdl4j</groupId>
     <artifactId>libre-wsdl4j</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>libre-wsdl4j</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>librewsdl4j</groupId>
     <artifactId>libre-wsdl4j</artifactId>
-    <version>1.6.4</version>
+    <version>1.7.0</version>
     <packaging>jar</packaging>
 
     <name>libre-wsdl4j</name>

--- a/src/main/java/com/ibm/wsdl/BindingOperationImpl.java
+++ b/src/main/java/com/ibm/wsdl/BindingOperationImpl.java
@@ -5,36 +5,30 @@
 package com.ibm.wsdl;
 
 import java.util.*;
-
 import javax.wsdl.*;
 
 /**
- * This class represents a WSDL operation binding.
- * That is, it holds the information that would be
- * specified in the operation element contained within
- * a binding element.
+ * This class represents a WSDL operation binding. That is, it holds the information that would be specified in the operation element contained within a binding element.
  *
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class BindingOperationImpl extends AbstractWSDLElement implements BindingOperation
-{
+public class BindingOperationImpl extends AbstractWSDLElement implements BindingOperation {
   protected String name = null;
   protected Operation operation = null;
   protected BindingInput bindingInput = null;
   protected BindingOutput bindingOutput = null;
-  protected Map bindingFaults = new HashMap();
-  protected List nativeAttributeNames =
-    Arrays.asList(Constants.BINDING_OPERATION_ATTR_NAMES);
+  private Map<String, BindingFault> bindingFaults = new HashMap<>();
+  private List<String> nativeAttributeNames = Arrays.asList(Constants.BINDING_OPERATION_ATTR_NAMES);
 
   public static final long serialVersionUID = 1;
 
   /**
    * Set the name of this operation binding.
    *
-   * @param name the desired name
+   * @param name
+   *          the desired name
    */
-  public void setName(String name)
-  {
+  public void setName(String name) {
     this.name = name;
   }
 
@@ -43,18 +37,17 @@ public class BindingOperationImpl extends AbstractWSDLElement implements Binding
    *
    * @return the operation binding name
    */
-  public String getName()
-  {
+  public String getName() {
     return name;
   }
 
   /**
    * Set the operation that this operation binding binds.
    *
-   * @param operation the operation this operation binding binds
+   * @param operation
+   *          the operation this operation binding binds
    */
-  public void setOperation(Operation operation)
-  {
+  public void setOperation(Operation operation) {
     this.operation = operation;
   }
 
@@ -63,18 +56,17 @@ public class BindingOperationImpl extends AbstractWSDLElement implements Binding
    *
    * @return the operation that this operation binding binds
    */
-  public Operation getOperation()
-  {
+  public Operation getOperation() {
     return operation;
   }
 
   /**
    * Set the input binding for this operation binding.
    *
-   * @param bindingInput the new input binding
+   * @param bindingInput
+   *          the new input binding
    */
-  public void setBindingInput(BindingInput bindingInput)
-  {
+  public void setBindingInput(BindingInput bindingInput) {
     this.bindingInput = bindingInput;
   }
 
@@ -83,18 +75,17 @@ public class BindingOperationImpl extends AbstractWSDLElement implements Binding
    *
    * @return the input binding
    */
-  public BindingInput getBindingInput()
-  {
+  public BindingInput getBindingInput() {
     return bindingInput;
   }
 
   /**
    * Set the output binding for this operation binding.
    *
-   * @param bindingOutput the new output binding
+   * @param bindingOutput
+   *          the new output binding
    */
-  public void setBindingOutput(BindingOutput bindingOutput)
-  {
+  public void setBindingOutput(BindingOutput bindingOutput) {
     this.bindingOutput = bindingOutput;
   }
 
@@ -103,42 +94,40 @@ public class BindingOperationImpl extends AbstractWSDLElement implements Binding
    *
    * @return the output binding for the operation binding
    */
-  public BindingOutput getBindingOutput()
-  {
+  public BindingOutput getBindingOutput() {
     return bindingOutput;
   }
 
   /**
    * Add a fault binding.
    *
-   * @param bindingFault the new fault binding
+   * @param bindingFault
+   *          the new fault binding
    */
-  public void addBindingFault(BindingFault bindingFault)
-  {
+  public void addBindingFault(BindingFault bindingFault) {
     bindingFaults.put(bindingFault.getName(), bindingFault);
   }
 
   /**
    * Get the specified fault binding.
    *
-   * @param name the name of the desired fault binding.
-   * @return the corresponding fault binding, or null if there wasn't
-   * any matching fault binding
+   * @param name
+   *          the name of the desired fault binding.
+   * @return the corresponding fault binding, or null if there wasn't any matching fault binding
    */
-  public BindingFault getBindingFault(String name)
-  {
-    return (BindingFault)bindingFaults.get(name);
+  public BindingFault getBindingFault(String name) {
+    return bindingFaults.get(name);
   }
-  
+
   /**
    * Remove the specified fault binding.
    *
-   * @param name the name of the fault binding to be removed.
+   * @param name
+   *          the name of the fault binding to be removed.
    * @return the fault binding which was removed
    */
-  public BindingFault removeBindingFault(String name)
-  {
-    return (BindingFault)bindingFaults.remove(name);
+  public BindingFault removeBindingFault(String name) {
+    return bindingFaults.remove(name);
   }
 
   /**
@@ -146,55 +135,46 @@ public class BindingOperationImpl extends AbstractWSDLElement implements Binding
    *
    * @return names of fault bindings
    */
-  public Map getBindingFaults()
-  {
+  public Map<String, BindingFault> getBindingFaults() {
     return bindingFaults;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("BindingOperation: name=" + name);
 
-    if (bindingInput != null)
-    {
+    if (bindingInput != null) {
       strBuf.append("\n" + bindingInput);
     }
 
-    if (bindingOutput != null)
-    {
+    if (bindingOutput != null) {
       strBuf.append("\n" + bindingOutput);
     }
 
-    if (bindingFaults != null)
-    {
-      Iterator faultIterator = bindingFaults.values().iterator();
+    if (bindingFaults != null) {
+      Iterator<BindingFault> faultIterator = bindingFaults.values().iterator();
 
-      while (faultIterator.hasNext())
-      {
+      while (faultIterator.hasNext()) {
         strBuf.append("\n" + faultIterator.next());
       }
     }
 
     String superString = super.toString();
-    if(!superString.equals(""))
-    {
+    if (!superString.equals("")) {
       strBuf.append("\n");
       strBuf.append(superString);
     }
 
     return strBuf.toString();
   }
-  
+
   /**
-   * Get the list of local attribute names defined for this element in
-   * the WSDL specification.
+   * Get the list of local attribute names defined for this element in the WSDL specification.
    *
    * @return a List of Strings, one for each local attribute name
    */
-  public List getNativeAttributeNames()
-  {
+  public List<String> getNativeAttributeNames() {
     return nativeAttributeNames;
   }
 }

--- a/src/main/java/com/ibm/wsdl/Constants.java
+++ b/src/main/java/com/ibm/wsdl/Constants.java
@@ -135,4 +135,6 @@ public class Constants
 
   // Other
   public static final String NONE = ":none";
+
+  private Constants() {}
 }

--- a/src/main/java/com/ibm/wsdl/DefinitionImpl.java
+++ b/src/main/java/com/ibm/wsdl/DefinitionImpl.java
@@ -5,7 +5,6 @@
 package com.ibm.wsdl;
 
 import java.util.*;
-
 import javax.wsdl.*;
 import javax.wsdl.extensions.*;
 import javax.xml.namespace.*;
@@ -17,33 +16,30 @@ import javax.xml.namespace.*;
  * @author Nirmal Mukhi
  * @author Matthew J. Duftler
  */
-public class DefinitionImpl extends AbstractWSDLElement implements Definition
-{
-  protected String documentBaseURI = null;
-  protected QName name = null;
-  protected String targetNamespace = null;
-  protected Map namespaces = new HashMap();
-  protected Map imports = new HashMap();
-  protected Types types = null;
-  protected Map messages = new HashMap();
-  protected Map bindings = new HashMap();
-  protected Map portTypes = new HashMap();
-  protected Map services = new HashMap();
-  protected List nativeAttributeNames =
-    Arrays.asList(Constants.DEFINITION_ATTR_NAMES);
-  protected ExtensionRegistry extReg = null;
+public class DefinitionImpl extends AbstractWSDLElement implements Definition {
+  private String documentBaseURI = null;
+  private QName name = null;
+  private String targetNamespace = null;
+  private Map<String, String> namespaces = new HashMap<>();
+  private Map<String, List<Import>> imports = new HashMap<>();
+  private Types types = null;
+  private Map<QName, Message> messages = new HashMap<>();
+  private Map<QName, Binding> bindings = new HashMap<>();
+  private Map<QName, PortType> portTypes = new HashMap<>();
+  private Map<QName, Service> services = new HashMap<>();
+  private List<String> nativeAttributeNames = Arrays.asList(Constants.DEFINITION_ATTR_NAMES);
+  private ExtensionRegistry extReg = null;
 
   public static final long serialVersionUID = 1;
 
   /**
-   * Set the document base URI of this definition. Can be used to
-   * represent the origin of the Definition, and can be exploited
-   * when resolving relative URIs (e.g. in &lt;import&gt;s).
+   * Set the document base URI of this definition. Can be used to represent the origin of the Definition, and can be exploited when resolving relative URIs (e.g. in &lt;import&gt;s).
    *
-   * @param documentBaseURI the document base URI of this definition
+   * @param documentBaseURI
+   *          the document base URI of this definition
    */
-  public void setDocumentBaseURI(String documentBaseURI)
-  {
+  @Override
+  public void setDocumentBaseURI(String documentBaseURI) {
     this.documentBaseURI = documentBaseURI;
   }
 
@@ -52,18 +48,19 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the document base URI
    */
-  public String getDocumentBaseURI()
-  {
+  @Override
+  public String getDocumentBaseURI() {
     return documentBaseURI;
   }
 
   /**
    * Set the name of this definition.
    *
-   * @param name the desired name
+   * @param name
+   *          the desired name
    */
-  public void setQName(QName name)
-  {
+  @Override
+  public void setQName(QName name) {
     this.name = name;
   }
 
@@ -72,145 +69,127 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the definition name
    */
-  public QName getQName()
-  {
+  @Override
+  public QName getQName() {
     return name;
   }
 
   /**
    * Set the target namespace in which WSDL elements are defined.
    *
-   * @param targetNamespace the target namespace
+   * @param targetNamespace
+   *          the target namespace
    */
-  public void setTargetNamespace(String targetNamespace)
-  {
+  @Override
+  public void setTargetNamespace(String targetNamespace) {
     this.targetNamespace = targetNamespace;
   }
 
   /**
-   * Get the target namespace in which the WSDL elements
-   * are defined.
+   * Get the target namespace in which the WSDL elements are defined.
    *
    * @return the target namespace
    */
-  public String getTargetNamespace()
-  {
+  @Override
+  public String getTargetNamespace() {
     return targetNamespace;
   }
 
   /**
-   * This is a way to add a namespace association to a definition.
-   * It is similar to adding a namespace prefix declaration to the
-   * top of a &lt;wsdl:definition&gt; element. This has nothing to do
-   * with the &lt;wsdl:import&gt; element; there are separate methods for
-   * dealing with information described by &lt;wsdl:import&gt; elements.
+   * This is a way to add a namespace association to a definition. It is similar to adding a namespace prefix declaration to the top of a &lt;wsdl:definition&gt; element. This has nothing to do with the &lt;wsdl:import&gt; element; there are separate methods for dealing with information described by
+   * &lt;wsdl:import&gt; elements.
    *
-   * @param prefix the prefix to use for this namespace (when
-   * rendering this information as XML). Use null or an empty string
-   * to describe the default namespace (i.e. xmlns="...").
-   * @param namespaceURI the namespace URI to associate the prefix
-   * with. If you use null, the namespace association will be removed.
+   * @param prefix
+   *          the prefix to use for this namespace (when rendering this information as XML). Use null or an empty string to describe the default namespace (i.e. xmlns="...").
+   * @param namespaceURI
+   *          the namespace URI to associate the prefix with. If you use null, the namespace association will be removed.
    */
-   public void addNamespace(String prefix, String namespaceURI)
-   {
-     if (prefix == null)
-     {
-       prefix = "";
-     }
+  @Override
+  public void addNamespace(String prefix, String namespaceURI) {
+    if (prefix == null) {
+      prefix = "";
+    }
 
-     if (namespaceURI != null)
-     {
-       namespaces.put(prefix, namespaceURI);
-     }
-     else
-     {
-       namespaces.remove(prefix);
-     }
-   }
+    if (namespaceURI != null) {
+      namespaces.put(prefix, namespaceURI);
+    } else {
+      namespaces.remove(prefix);
+    }
+  }
 
-   /**
-    * Get the namespace URI associated with this prefix. Or null if
-    * there is no namespace URI associated with this prefix. This is
-    * unrelated to the &lt;wsdl:import&gt; element.
-    *
-    * @see #addNamespace(String, String)
-    * @see #getPrefix(String)
-    */
-   public String getNamespace(String prefix)
-   {
-     if (prefix == null)
-     {
-       prefix = "";
-     }
+  /**
+   * Get the namespace URI associated with this prefix. Or null if there is no namespace URI associated with this prefix. This is unrelated to the &lt;wsdl:import&gt; element.
+   *
+   * @see #addNamespace(String, String)
+   * @see #getPrefix(String)
+   */
+  @Override
+  public String getNamespace(String prefix) {
+    if (prefix == null) {
+      prefix = "";
+    }
 
-     return (String)namespaces.get(prefix);
-   }
-   
-   /**
-    * Remove the namespace URI associated with this prefix.
-    *
-    * @param prefix the prefix of the namespace to be removed.
-    * @return the namespace URI which was removed
-    */
-   public String removeNamespace(String prefix)
-   {
-     if (prefix == null)
-     {
-       prefix = "";
-     }
+    return namespaces.get(prefix);
+  }
 
-     return (String)namespaces.remove(prefix);
-   }
+  /**
+   * Remove the namespace URI associated with this prefix.
+   *
+   * @param prefix
+   *          the prefix of the namespace to be removed.
+   * @return the namespace URI which was removed
+   */
+  @Override
+  public String removeNamespace(String prefix) {
+    if (prefix == null) {
+      prefix = "";
+    }
 
-   /**
-    * Get a prefix associated with this namespace URI. Or null if
-    * there are no prefixes associated with this namespace URI. This is
-    * unrelated to the &lt;wsdl:import&gt; element.
-    *
-    * @see #addNamespace(String, String)
-    * @see #getNamespace(String)
-    */
-   public String getPrefix(String namespaceURI)
-   {
-     if (namespaceURI == null)
-     {
-       return null;
-     }
+    return namespaces.remove(prefix);
+  }
 
-     Iterator entryIterator = namespaces.entrySet().iterator();
+  /**
+   * Get a prefix associated with this namespace URI. Or null if there are no prefixes associated with this namespace URI. This is unrelated to the &lt;wsdl:import&gt; element.
+   *
+   * @see #addNamespace(String, String)
+   * @see #getNamespace(String)
+   */
+  @Override
+  public String getPrefix(String namespaceURI) {
+    if (namespaceURI == null) {
+      return null;
+    }
 
-     while (entryIterator.hasNext())
-     {
-       Map.Entry entry = (Map.Entry)entryIterator.next();
-       String prefix = (String)entry.getKey();
-       String assocNamespaceURI = (String)entry.getValue();
+    Iterator<Map.Entry<String, String>> entryIterator = namespaces.entrySet().iterator();
 
-       if (namespaceURI.equals(assocNamespaceURI))
-       {
-         return prefix;
-       }
-     }
+    while (entryIterator.hasNext()) {
+      Map.Entry<String, String> entry = entryIterator.next();
+      String prefix = entry.getKey();
+      String assocNamespaceURI = entry.getValue();
 
-     return null;
-   }
+      if (namespaceURI.equals(assocNamespaceURI)) {
+        return prefix;
+      }
+    }
 
-   /**
-    * Get all namespace associations in this definition. The keys are
-    * the prefixes, and the namespace URIs are the values. This is
-    * unrelated to the &lt;wsdl:import&gt; element.
-    *
-    * @see #addNamespace(String, String)
-    */
-   public Map getNamespaces()
-   {
-     return namespaces;
-   }
+    return null;
+  }
+
+  /**
+   * Get all namespace associations in this definition. The keys are the prefixes, and the namespace URIs are the values. This is unrelated to the &lt;wsdl:import&gt; element.
+   *
+   * @see #addNamespace(String, String)
+   */
+  @Override
+  public Map<String, String> getNamespaces() {
+    return namespaces;
+  }
 
   /**
    * Set the types section.
    */
-  public void setTypes(Types types)
-  {
+  @Override
+  public void setTypes(Types types) {
     this.types = types;
   }
 
@@ -219,44 +198,36 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the types section
    */
-  public Types getTypes()
-  {
+  @Override
+  public Types getTypes() {
     return types;
   }
 
   /**
    * Add an import to this WSDL description.
    *
-   * @param importDef the import to be added
+   * @param importDef
+   *          the import to be added
    */
-  public void addImport(Import importDef)
-  {
+  @Override
+  public void addImport(Import importDef) {
     String namespaceURI = importDef.getNamespaceURI();
-    List importList = (List)imports.get(namespaceURI);
-
-    if (importList == null)
-    {
-      importList = new Vector();
-
-      imports.put(namespaceURI, importList);
-    }
-
+    List<Import> importList = imports.computeIfAbsent(namespaceURI, key -> new ArrayList<>());
     importList.add(importDef);
   }
-  
+
   /**
    * Remove an import from this WSDL description.
    *
-   * @param importDef the import to be removed
+   * @param importDef
+   *          the import to be removed
    */
-  public Import removeImport(Import importDef)
-  {
+  @Override
+  public Import removeImport(Import importDef) {
     String namespaceURI = importDef.getNamespaceURI();
-    List importList = (List)imports.get(namespaceURI);
-
+    List<Import> importList = imports.get(namespaceURI);
     Import removed = null;
-    if (importList != null && importList.remove(importDef))
-    {
+    if (importList != null && importList.remove(importDef)) {
       removed = importDef;
     }
     return removed;
@@ -265,51 +236,47 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   /**
    * Get the list of imports for the specified namespaceURI.
    *
-   * @param namespaceURI the namespaceURI associated with the
-   * desired imports.
-   * @return a list of the corresponding imports, or null if
-   * there weren't any matching imports
+   * @param namespaceURI
+   *          the namespaceURI associated with the desired imports.
+   * @return a list of the corresponding imports, or null if there weren't any matching imports
    */
-  public List getImports(String namespaceURI)
-  {
-    return (List)imports.get(namespaceURI);
+  @Override
+  public List<Import> getImports(String namespaceURI) {
+    return imports.get(namespaceURI);
   }
 
   /**
-   * Get a map of lists containing all the imports defined here.
-   * The map's keys are the namespaceURIs, and the map's values
-   * are lists. There is one list for each namespaceURI for which
-   * imports have been defined.
+   * Get a map of lists containing all the imports defined here. The map's keys are the namespaceURIs, and the map's values are lists. There is one list for each namespaceURI for which imports have been defined.
    */
-  public Map getImports()
-  {
+  @Override
+  public Map<String, List<Import>> getImports() {
     return imports;
   }
 
   /**
    * Add a message to this WSDL description.
    *
-   * @param message the message to be added
+   * @param message
+   *          the message to be added
    */
-  public void addMessage(Message message)
-  {
+  @Override
+  public void addMessage(Message message) {
     messages.put(message.getQName(), message);
   }
 
   /**
    * Get the specified message. Also checks imported documents.
    *
-   * @param name the name of the desired message.
-   * @return the corresponding message, or null if there wasn't
-   * any matching message
+   * @param name
+   *          the name of the desired message.
+   * @return the corresponding message, or null if there wasn't any matching message
    */
-  public Message getMessage(QName name)
-  {
-    Message message = (Message)messages.get(name);
+  @Override
+  public Message getMessage(QName name) {
+    Message message = messages.get(name);
 
-    if (message == null && name != null)
-    {
-      message = (Message)getFromImports(Constants.ELEM_MESSAGE, name);
+    if (message == null && name != null) {
+      message = (Message) getFromImports(Constants.ELEM_MESSAGE, name);
     }
 
     return message;
@@ -318,47 +285,47 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   /**
    * Remove the specified message from this definition.
    *
-   * @param name the name of the message to remove
-   * @return the message previously associated with this qname, if there
-   * was one; may return null
+   * @param name
+   *          the name of the message to remove
+   * @return the message previously associated with this qname, if there was one; may return null
    */
-  public Message removeMessage(QName name)
-  {
-    return (Message) messages.remove(name);
+  @Override
+  public Message removeMessage(QName name) {
+    return messages.remove(name);
   }
 
   /**
    * Get all the messages defined here.
    */
-  public Map getMessages()
-  {
+  @Override
+  public Map<QName, Message> getMessages() {
     return messages;
   }
 
   /**
    * Add a binding to this WSDL description.
    *
-   * @param binding the binding to be added
+   * @param binding
+   *          the binding to be added
    */
-  public void addBinding(Binding binding)
-  {
+  @Override
+  public void addBinding(Binding binding) {
     bindings.put(binding.getQName(), binding);
   }
 
   /**
    * Get the specified binding. Also checks imported documents.
    *
-   * @param name the name of the desired binding.
-   * @return the corresponding binding, or null if there wasn't
-   * any matching binding
+   * @param name
+   *          the name of the desired binding.
+   * @return the corresponding binding, or null if there wasn't any matching binding
    */
-  public Binding getBinding(QName name)
-  {
-    Binding binding = (Binding)bindings.get(name);
+  @Override
+  public Binding getBinding(QName name) {
+    Binding binding = bindings.get(name);
 
-    if (binding == null && name != null)
-    {
-      binding = (Binding)getFromImports(Constants.ELEM_BINDING, name);
+    if (binding == null && name != null) {
+      binding = (Binding) getFromImports(Constants.ELEM_BINDING, name);
     }
 
     return binding;
@@ -367,47 +334,47 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   /**
    * Remove the specified binding from this definition.
    *
-   * @param name the name of the binding to remove
-   * @return the binding previously associated with this qname, if there
-   * was one; may return null
+   * @param name
+   *          the name of the binding to remove
+   * @return the binding previously associated with this qname, if there was one; may return null
    */
-  public Binding removeBinding(QName name)
-  {
-    return (Binding) bindings.remove(name);
+  @Override
+  public Binding removeBinding(QName name) {
+    return bindings.remove(name);
   }
 
   /**
    * Get all the bindings defined in this Definition.
    */
-  public Map getBindings()
-  {
+  @Override
+  public Map<QName, Binding> getBindings() {
     return bindings;
   }
 
   /**
    * Add a portType to this WSDL description.
    *
-   * @param portType the portType to be added
+   * @param portType
+   *          the portType to be added
    */
-  public void addPortType(PortType portType)
-  {
+  @Override
+  public void addPortType(PortType portType) {
     portTypes.put(portType.getQName(), portType);
   }
 
   /**
    * Get the specified portType. Also checks imported documents.
    *
-   * @param name the name of the desired portType.
-   * @return the corresponding portType, or null if there wasn't
-   * any matching portType
+   * @param name
+   *          the name of the desired portType.
+   * @return the corresponding portType, or null if there wasn't any matching portType
    */
-  public PortType getPortType(QName name)
-  {
-    PortType portType = (PortType)portTypes.get(name);
+  @Override
+  public PortType getPortType(QName name) {
+    PortType portType = portTypes.get(name);
 
-    if (portType == null && name != null)
-    {
-      portType = (PortType)getFromImports(Constants.ELEM_PORT_TYPE, name);
+    if (portType == null && name != null) {
+      portType = (PortType) getFromImports(Constants.ELEM_PORT_TYPE, name);
     }
 
     return portType;
@@ -416,47 +383,47 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   /**
    * Remove the specified portType from this definition.
    *
-   * @param name the name of the portType to remove
-   * @return the portType previously associated with this qname, if there
-   * was one; may return null
+   * @param name
+   *          the name of the portType to remove
+   * @return the portType previously associated with this qname, if there was one; may return null
    */
-  public PortType removePortType(QName name)
-  {
-    return (PortType) portTypes.remove(name);
+  @Override
+  public PortType removePortType(QName name) {
+    return portTypes.remove(name);
   }
 
   /**
    * Get all the portTypes defined in this Definition.
    */
-  public Map getPortTypes()
-  {
+  @Override
+  public Map<QName, PortType> getPortTypes() {
     return portTypes;
   }
 
   /**
    * Add a service to this WSDL description.
    *
-   * @param service the service to be added
+   * @param service
+   *          the service to be added
    */
-  public void addService(Service service)
-  {
+  @Override
+  public void addService(Service service) {
     services.put(service.getQName(), service);
   }
 
   /**
    * Get the specified service. Also checks imported documents.
    *
-   * @param name the name of the desired service.
-   * @return the corresponding service, or null if there wasn't
-   * any matching service
+   * @param name
+   *          the name of the desired service.
+   * @return the corresponding service, or null if there wasn't any matching service
    */
-  public Service getService(QName name)
-  {
-    Service service = (Service)services.get(name);
+  @Override
+  public Service getService(QName name) {
+    Service service = services.get(name);
 
-    if (service == null && name != null)
-    {
-      service = (Service)getFromImports(Constants.ELEM_SERVICE, name);
+    if (service == null && name != null) {
+      service = (Service) getFromImports(Constants.ELEM_SERVICE, name);
     }
 
     return service;
@@ -465,20 +432,20 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   /**
    * Remove the specified service from this definition.
    *
-   * @param name the name of the service to remove
-   * @return the service previously associated with this qname, if there
-   * was one; may return null
+   * @param name
+   *          the name of the service to remove
+   * @return the service previously associated with this qname, if there was one; may return null
    */
-  public Service removeService(QName name)
-  {
-    return (Service) services.remove(name);
+  @Override
+  public Service removeService(QName name) {
+    return services.remove(name);
   }
 
   /**
    * Get all the services defined in this Definition.
    */
-  public Map getServices()
-  {
+  @Override
+  public Map<QName, Service> getServices() {
     return services;
   }
 
@@ -487,8 +454,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created binding
    */
-  public Binding createBinding()
-  {
+  @Override
+  public Binding createBinding() {
     return new BindingImpl();
   }
 
@@ -497,8 +464,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created binding fault
    */
-  public BindingFault createBindingFault()
-  {
+  @Override
+  public BindingFault createBindingFault() {
     return new BindingFaultImpl();
   }
 
@@ -507,8 +474,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created binding input
    */
-  public BindingInput createBindingInput()
-  {
+  @Override
+  public BindingInput createBindingInput() {
     return new BindingInputImpl();
   }
 
@@ -517,8 +484,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created binding operation
    */
-  public BindingOperation createBindingOperation()
-  {
+  @Override
+  public BindingOperation createBindingOperation() {
     return new BindingOperationImpl();
   }
 
@@ -527,8 +494,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created binding output
    */
-  public BindingOutput createBindingOutput()
-  {
+  @Override
+  public BindingOutput createBindingOutput() {
     return new BindingOutputImpl();
   }
 
@@ -537,8 +504,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created fault
    */
-  public Fault createFault()
-  {
+  @Override
+  public Fault createFault() {
     return new FaultImpl();
   }
 
@@ -547,8 +514,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created import
    */
-  public Import createImport()
-  {
+  @Override
+  public Import createImport() {
     return new ImportImpl();
   }
 
@@ -557,8 +524,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created input
    */
-  public Input createInput()
-  {
+  @Override
+  public Input createInput() {
     return new InputImpl();
   }
 
@@ -567,8 +534,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created message
    */
-  public Message createMessage()
-  {
+  @Override
+  public Message createMessage() {
     return new MessageImpl();
   }
 
@@ -577,8 +544,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created operation
    */
-  public Operation createOperation()
-  {
+  @Override
+  public Operation createOperation() {
     return new OperationImpl();
   }
 
@@ -587,8 +554,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created output
    */
-  public Output createOutput()
-  {
+  @Override
+  public Output createOutput() {
     return new OutputImpl();
   }
 
@@ -597,8 +564,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created part
    */
-  public Part createPart()
-  {
+  @Override
+  public Part createPart() {
     return new PartImpl();
   }
 
@@ -607,8 +574,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created port
    */
-  public Port createPort()
-  {
+  @Override
+  public Port createPort() {
     return new PortImpl();
   }
 
@@ -617,8 +584,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created port type
    */
-  public PortType createPortType()
-  {
+  @Override
+  public PortType createPortType() {
     return new PortTypeImpl();
   }
 
@@ -627,8 +594,8 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created service
    */
-  public Service createService()
-  {
+  @Override
+  public Service createService() {
     return new ServiceImpl();
   }
 
@@ -637,75 +604,60 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
    *
    * @return the newly created types section
    */
-  public Types createTypes()
-  {
+  @Override
+  public Types createTypes() {
     return new TypesImpl();
   }
 
   /**
    * Set the ExtensionRegistry for this Definition.
    */
-  public void setExtensionRegistry(ExtensionRegistry extReg)
-  {
+  @Override
+  public void setExtensionRegistry(ExtensionRegistry extReg) {
     this.extReg = extReg;
   }
 
   /**
    * Get a reference to the ExtensionRegistry for this Definition.
    */
-  public ExtensionRegistry getExtensionRegistry()
-  {
+  @Override
+  public ExtensionRegistry getExtensionRegistry() {
     return extReg;
   }
 
-  private Object getFromImports(String typeOfDefinition, QName name)
-  {
-    Object ret = null;
-    List importList = getImports(name.getNamespaceURI());
+  private WSDLElement getFromImports(String typeOfDefinition, QName name) {
+    WSDLElement ret = null;
+    List<Import> importList = getImports(name.getNamespaceURI());
+    if (importList == null) {
+      return null;
+    }
+    Iterator<Import> importIterator = importList.iterator();
+    while (importIterator.hasNext()) {
+      Import importDef = importIterator.next();
+      Definition importedDef = importDef.getDefinition();
 
-    if (importList != null)
-    {
-      Iterator importIterator = importList.iterator();
+      if (importedDef != null) {
+        // These object comparisons will work fine because this private method is only called from within this class,
+        // using only the pre-defined constants from the Constants class as the typeOfDefinition argument.
+        switch (typeOfDefinition) {
+          case Constants.ELEM_SERVICE:
+            ret = importedDef.getService(name);
+            break;
+          case Constants.ELEM_MESSAGE:
+            ret = importedDef.getMessage(name);
+            break;
+          case Constants.ELEM_BINDING:
+            ret = importedDef.getBinding(name);
+            break;
+          case Constants.ELEM_PORT_TYPE:
+            ret = importedDef.getPortType(name);
+            break;
+          default:
+            break;
+        }
 
-      while (importIterator.hasNext())
-      {
-        Import importDef = (Import)importIterator.next();
-
-        if (importDef != null)
-        {
-          Definition importedDef = importDef.getDefinition();
-    
-          if (importedDef != null)
-          {
-            /*
-              These object comparisons will work fine because
-              this private method is only called from within
-              this class, using only the pre-defined constants
-              from the Constants class as the typeOfDefinition
-              argument.
-            */
-            if (typeOfDefinition == Constants.ELEM_SERVICE)
-            {
-              ret = importedDef.getService(name);
-            }
-            else if (typeOfDefinition == Constants.ELEM_MESSAGE)
-            {
-              ret = importedDef.getMessage(name);
-            }
-            else if (typeOfDefinition == Constants.ELEM_BINDING)
-            {
-              ret = importedDef.getBinding(name);
-            }
-            else if (typeOfDefinition == Constants.ELEM_PORT_TYPE)
-            {
-              ret = importedDef.getPortType(name);
-            }
-
-            if (ret != null)
-            {
-              return ret;
-            }
-          }
+        if (ret != null) {
+          return ret;
         }
       }
     }
@@ -713,109 +665,79 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
     return ret;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  private <T extends WSDLElement> void appendElementToStringBuilder(Map<?, T> element, StringBuilder sb) {
+    if (element != null) {
+      Iterator<T> importIterator = element.values().iterator();
+      while (importIterator.hasNext()) {
+        sb.append("\n" + importIterator.next());
+      }
+    }
 
-    strBuf.append("Definition: name=" + name +
-                  " targetNamespace=" + targetNamespace);
+  }
 
-    if (imports != null)
-    {
-      Iterator importIterator = imports.values().iterator();
+  @Override
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
-      while (importIterator.hasNext())
-      {
+    strBuf.append("Definition: name=" + name + " targetNamespace=" + targetNamespace);
+
+    // Imports
+    if (imports != null) {
+      Iterator<List<Import>> importIterator = imports.values().iterator();
+      while (importIterator.hasNext()) {
         strBuf.append("\n" + importIterator.next());
       }
     }
 
-    if (types != null)
-    {
+    // Types
+    if (types != null) {
       strBuf.append("\n" + types);
     }
 
-    if (messages != null)
-    {
-      Iterator msgsIterator = messages.values().iterator();
-
-      while (msgsIterator.hasNext())
-      {
-        strBuf.append("\n" + msgsIterator.next());
-      }
-    }
-
-    if (portTypes != null)
-    {
-      Iterator portTypeIterator = portTypes.values().iterator();
-
-      while (portTypeIterator.hasNext())
-      {
-        strBuf.append("\n" + portTypeIterator.next());
-      }
-    }
-
-    if (bindings != null)
-    {
-      Iterator bindingIterator = bindings.values().iterator();
-
-      while (bindingIterator.hasNext())
-      {
-        strBuf.append("\n" + bindingIterator.next());
-      }
-    }
-
-    if (services != null)
-    {
-      Iterator serviceIterator = services.values().iterator();
-
-      while (serviceIterator.hasNext())
-      {
-        strBuf.append("\n" + serviceIterator.next());
-      }
-    }
+    // Messages
+    appendElementToStringBuilder(this.messages, strBuf);
+    // Port types
+    appendElementToStringBuilder(this.portTypes, strBuf);
+    // Bindings
+    appendElementToStringBuilder(this.bindings, strBuf);
+    // Services
+    appendElementToStringBuilder(this.services, strBuf);
 
     String superString = super.toString();
-    if(!superString.equals(""))
-    {
+    if (!superString.equals("")) {
       strBuf.append("\n");
       strBuf.append(superString);
     }
-    
+
     return strBuf.toString();
   }
-  
+
   /**
-   * Get the list of local attribute names defined for this element in
-   * the WSDL specification.
+   * Get the list of local attribute names defined for this element in the WSDL specification.
    *
    * @return a List of Strings, one for each local attribute name
    */
-  public List getNativeAttributeNames()
-  {
+  @Override
+  public List<String> getNativeAttributeNames() {
     return nativeAttributeNames;
   }
 
   /**
-   * Get all the bindings defined in this Definition and
-   * those in any imported Definitions in the WSDL tree.
+   * Get all the bindings defined in this Definition and those in any imported Definitions in the WSDL tree.
    */
-  public Map getAllBindings()
-  {
-    Map allBindings = new HashMap(getBindings());
-    Map importMap = getImports();
-    Iterator mapItr = importMap.values().iterator();
-    while(mapItr.hasNext())
-    {
-      Vector importDefs = (Vector) mapItr.next();
-      Iterator vecItr = importDefs.iterator();
-      while(vecItr.hasNext())
-      {
-        Import importDef = (Import) vecItr.next(); 
+  @Override
+  public Map<QName, Binding> getAllBindings() {
+    Map<QName, Binding> allBindings = new HashMap<>(getBindings());
+    Map<String, List<Import>> importMap = getImports();
+    Iterator<List<Import>> mapItr = importMap.values().iterator();
+    while (mapItr.hasNext()) {
+      List<Import> importDefs = mapItr.next();
+      Iterator<Import> importItr = importDefs.iterator();
+      while (importItr.hasNext()) {
+        Import importDef = importItr.next();
         Definition importedDef = importDef.getDefinition();
-        //importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
-        if(importedDef != null)
-        {
+        // importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
+        if (importedDef != null) {
           allBindings.putAll(importedDef.getAllBindings());
         }
       }
@@ -824,25 +746,21 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   }
 
   /**
-   * Get all the portTypes defined in this Definition and
-   * those in any imported Definitions in the WSDL tree.
+   * Get all the portTypes defined in this Definition and those in any imported Definitions in the WSDL tree.
    */
-  public Map getAllPortTypes()
-  {
-    Map allPortTypes = new HashMap(getPortTypes());
-    Map importMap = getImports();
-    Iterator mapItr = importMap.values().iterator();
-    while(mapItr.hasNext())
-    {
-      Vector importDefs = (Vector) mapItr.next();
-      Iterator vecItr = importDefs.iterator();
-      while(vecItr.hasNext())
-      {
-        Import importDef = (Import) vecItr.next(); 
+  @Override
+  public Map<QName, PortType> getAllPortTypes() {
+    Map<QName, PortType> allPortTypes = new HashMap<>(getPortTypes());
+    Map<String, List<Import>> importMap = getImports();
+    Iterator<List<Import>> mapItr = importMap.values().iterator();
+    while (mapItr.hasNext()) {
+      List<Import> importDefs = mapItr.next();
+      Iterator<Import> importItr = importDefs.iterator();
+      while (importItr.hasNext()) {
+        Import importDef = importItr.next();
         Definition importedDef = importDef.getDefinition();
-        //importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
-        if(importedDef != null)
-        {
+        // importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
+        if (importedDef != null) {
           allPortTypes.putAll(importedDef.getAllPortTypes());
         }
       }
@@ -851,25 +769,21 @@ public class DefinitionImpl extends AbstractWSDLElement implements Definition
   }
 
   /**
-   * Get all the services defined in this Definition and
-   * those in any imported Definitions in the WSDL tree.
+   * Get all the services defined in this Definition and those in any imported Definitions in the WSDL tree.
    */
-  public Map getAllServices()
-  {
-    Map allServices = new HashMap(getServices());
-    Map importMap = getImports();
-    Iterator mapItr = importMap.values().iterator();
-    while(mapItr.hasNext())
-    {
-      Vector importDefs = (Vector) mapItr.next();
-      Iterator vecItr = importDefs.iterator();
-      while(vecItr.hasNext())
-      {
-        Import importDef = (Import) vecItr.next(); 
+  @Override
+  public Map<QName, Service> getAllServices() {
+    Map<QName, Service> allServices = new HashMap<>(getServices());
+    Map<String, List<Import>> importMap = getImports();
+    Iterator<List<Import>> mapItr = importMap.values().iterator();
+    while (mapItr.hasNext()) {
+      List<Import> importDefs = mapItr.next();
+      Iterator<Import> importItr = importDefs.iterator();
+      while (importItr.hasNext()) {
+        Import importDef = importItr.next();
         Definition importedDef = importDef.getDefinition();
-        //importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
-        if(importedDef != null)
-        {
+        // importedDef may be null (e.g. if the javax.wsdl.importDocuments feature is disabled).
+        if (importedDef != null) {
           allServices.putAll(importedDef.getAllServices());
         }
       }

--- a/src/main/java/com/ibm/wsdl/OperationImpl.java
+++ b/src/main/java/com/ibm/wsdl/OperationImpl.java
@@ -5,28 +5,23 @@
 package com.ibm.wsdl;
 
 import java.util.*;
-
 import javax.wsdl.*;
 
 /**
- * This class represents a WSDL operation.
- * It includes information on input, output and fault
- * messages associated with usage of the operation.
+ * This class represents a WSDL operation. It includes information on input, output and fault messages associated with usage of the operation.
  *
  * @author Paul Fremantle (pzf@us.ibm.com)
  * @author Nirmal Mukhi (nmukhi@us.ibm.com)
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class OperationImpl extends AbstractWSDLElement implements Operation
-{
+public class OperationImpl extends AbstractWSDLElement implements Operation {
   protected String name = null;
   protected Input input = null;
   protected Output output = null;
-  protected Map faults = new HashMap();
-  protected OperationType style = null;
-  protected List parameterOrder = null;
-  protected List nativeAttributeNames =
-    Arrays.asList(Constants.OPERATION_ATTR_NAMES);
+  private Map<String, Fault> faults = new HashMap<>();
+  private OperationType style = null;
+  private List<String> parameterOrder = null;
+  private List<String> nativeAttributeNames = Arrays.asList(Constants.OPERATION_ATTR_NAMES);
   protected boolean isUndefined = true;
 
   public static final long serialVersionUID = 1;
@@ -34,10 +29,11 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
   /**
    * Set the name of this operation.
    *
-   * @param name the desired name
+   * @param name
+   *          the desired name
    */
-  public void setName(String name)
-  {
+  @Override
+  public void setName(String name) {
     this.name = name;
   }
 
@@ -46,18 +42,19 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
    *
    * @return the operation name
    */
-  public String getName()
-  {
+  @Override
+  public String getName() {
     return name;
   }
 
   /**
    * Set the input message specification for this operation.
    *
-   * @param input the new input message
+   * @param input
+   *          the new input message
    */
-  public void setInput(Input input)
-  {
+  @Override
+  public void setInput(Input input) {
     this.input = input;
   }
 
@@ -66,18 +63,19 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
    *
    * @return the input message
    */
-  public Input getInput()
-  {
+  @Override
+  public Input getInput() {
     return input;
   }
 
   /**
    * Set the output message specification for this operation.
    *
-   * @param output the new output message
+   * @param output
+   *          the new output message
    */
-  public void setOutput(Output output)
-  {
+  @Override
+  public void setOutput(Output output) {
     this.output = output;
   }
 
@@ -86,43 +84,44 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
    *
    * @return the output message specification for the operation
    */
-  public Output getOutput()
-  {
+  @Override
+  public Output getOutput() {
     return output;
   }
 
   /**
-   * Add a fault message that must be associated with this
-   * operation.
+   * Add a fault message that must be associated with this operation.
    *
-   * @param fault the new fault message
+   * @param fault
+   *          the new fault message
    */
-  public void addFault(Fault fault)
-  {
+  @Override
+  public void addFault(Fault fault) {
     faults.put(fault.getName(), fault);
   }
 
   /**
    * Get the specified fault message.
    *
-   * @param name the name of the desired fault message.
-   * @return the corresponding fault message, or null if there wasn't
-   * any matching message
+   * @param name
+   *          the name of the desired fault message.
+   * @return the corresponding fault message, or null if there wasn't any matching message
    */
-  public Fault getFault(String name)
-  {
-    return (Fault)faults.get(name);
+  @Override
+  public Fault getFault(String name) {
+    return faults.get(name);
   }
-  
+
   /**
    * Remove the specified fault message.
    *
-   * @param name the name of the fault message to be removed
+   * @param name
+   *          the name of the fault message to be removed
    * @return the fault message which was removed.
    */
-  public Fault removeFault(String name)
-  {
-    return (Fault)faults.remove(name);
+  @Override
+  public Fault removeFault(String name) {
+    return faults.remove(name);
   }
 
   /**
@@ -130,19 +129,19 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
    *
    * @return names of fault messages
    */
-  public Map getFaults()
-  {
+  @Override
+  public Map<String, Fault> getFaults() {
     return faults;
   }
 
   /**
-   * Set the style for this operation (request-response,
-   * one way, solicit-response or notification).
+   * Set the style for this operation (request-response, one way, solicit-response or notification).
    *
-   * @param style the new operation style
+   * @param style
+   *          the new operation style
    */
-  public void setStyle(OperationType style)
-  {
+  @Override
+  public void setStyle(OperationType style) {
     this.style = style;
   }
 
@@ -151,99 +150,87 @@ public class OperationImpl extends AbstractWSDLElement implements Operation
    *
    * @return the operation type
    */
-  public OperationType getStyle()
-  {
+  @Override
+  public OperationType getStyle() {
     return style;
   }
 
   /**
-   * Set the parameter ordering for a request-response,
-   * or solicit-response operation.
+   * Set the parameter ordering for a request-response, or solicit-response operation.
    *
-   * @param parameterOrder a list of named parameters
-   * containing the part names to reflect the desired
-   * order of parameters for RPC-style operations
+   * @param parameterOrder
+   *          a list of named parameters containing the part names to reflect the desired order of parameters for RPC-style operations
    */
-  public void setParameterOrdering(List parameterOrder)
-  {
+  @Override
+  public void setParameterOrdering(List<String> parameterOrder) {
     this.parameterOrder = parameterOrder;
   }
 
   /**
    * Get the parameter ordering for this operation.
    *
-   * @return the parameter ordering, a list consisting
-   * of message part names
+   * @return the parameter ordering, a list consisting of message part names
    */
-  public List getParameterOrdering()
-  {
+  @Override
+  public List<String> getParameterOrdering() {
     return parameterOrder;
   }
 
-  public void setUndefined(boolean isUndefined)
-  {
+  @Override
+  public void setUndefined(boolean isUndefined) {
     this.isUndefined = isUndefined;
   }
 
-  public boolean isUndefined()
-  {
+  @Override
+  public boolean isUndefined() {
     return isUndefined;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  @Override
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("Operation: name=" + name);
 
-    if (parameterOrder != null)
-    {
+    if (parameterOrder != null) {
       strBuf.append("\nparameterOrder=" + parameterOrder);
     }
 
-    if (style != null)
-    {
+    if (style != null) {
       strBuf.append("\nstyle=" + style);
     }
 
-    if (input != null)
-    {
+    if (input != null) {
       strBuf.append("\n" + input);
     }
 
-    if (output != null)
-    {
+    if (output != null) {
       strBuf.append("\n" + output);
     }
 
-    if (faults != null)
-    {
-      Iterator faultIterator = faults.values().iterator();
+    if (faults != null) {
+      Iterator<Fault> faultIterator = faults.values().iterator();
 
-      while (faultIterator.hasNext())
-      {
+      while (faultIterator.hasNext()) {
         strBuf.append("\n" + faultIterator.next());
       }
     }
 
     String superString = super.toString();
-    if(!superString.equals(""))
-    {
+    if (!superString.equals("")) {
       strBuf.append("\n");
       strBuf.append(superString);
     }
-    
+
     return strBuf.toString();
   }
-  
+
   /**
-   * Get the list of local attribute names defined for this element in
-   * the WSDL specification.
+   * Get the list of local attribute names defined for this element in the WSDL specification.
    *
    * @return a List of Strings, one for each local attribute name
    */
-  public List getNativeAttributeNames()
-  {
+  public List<String> getNativeAttributeNames() {
     return nativeAttributeNames;
   }
 }

--- a/src/main/java/com/ibm/wsdl/ServiceImpl.java
+++ b/src/main/java/com/ibm/wsdl/ServiceImpl.java
@@ -5,34 +5,30 @@
 package com.ibm.wsdl;
 
 import java.util.*;
-
 import javax.wsdl.*;
 import javax.xml.namespace.*;
 
 /**
- * This class represents a service, which groups related
- * ports to provide some functionality.
+ * This class represents a service, which groups related ports to provide some functionality.
  *
  * @author Paul Fremantle
  * @author Nirmal Mukhi
  * @author Matthew J. Duftler
  */
-public class ServiceImpl extends AbstractWSDLElement implements Service
-{
-  protected QName name = null;
-  protected Map ports = new HashMap();
-  protected List nativeAttributeNames =
-    Arrays.asList(Constants.SERVICE_ATTR_NAMES);
+public class ServiceImpl extends AbstractWSDLElement implements Service {
+  private QName name = null;
+  private Map<String, Port> ports = new HashMap<>();
+  private List<String> nativeAttributeNames = Arrays.asList(Constants.SERVICE_ATTR_NAMES);
 
   public static final long serialVersionUID = 1;
 
   /**
    * Set the name of this service.
    *
-   * @param name the desired name
+   * @param name
+   *          the desired name
    */
-  public void setQName(QName name)
-  {
+  public void setQName(QName name) {
     this.name = name;
   }
 
@@ -41,86 +37,77 @@ public class ServiceImpl extends AbstractWSDLElement implements Service
    *
    * @return the service name
    */
-  public QName getQName()
-  {
+  public QName getQName() {
     return name;
   }
 
   /**
    * Add a port to this service.
    *
-   * @param port the port to be added
+   * @param port
+   *          the port to be added
    */
-  public void addPort(Port port)
-  {
+  public void addPort(Port port) {
     ports.put(port.getName(), port);
   }
 
   /**
    * Get the specified port.
    *
-   * @param name the name of the desired port.
-   * @return the corresponding port, or null if there wasn't
-   * any matching port
+   * @param name
+   *          the name of the desired port.
+   * @return the corresponding port, or null if there wasn't any matching port
    */
-  public Port getPort(String name)
-  {
-    return (Port)ports.get(name);
+  public Port getPort(String name) {
+    return ports.get(name);
   }
-  
+
   /**
    * Remove the specified port.
    *
-   * @param name the name of the port to be removed.
+   * @param name
+   *          the name of the port to be removed.
    * @return the port which was removed
    */
-  public Port removePort(String name)
-  {
-    return (Port)ports.remove(name);
+  public Port removePort(String name) {
+    return ports.remove(name);
   }
 
   /**
    * Get all the ports defined here.
    */
-  public Map getPorts()
-  {
+  public Map<String, Port> getPorts() {
     return ports;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("Service: name=" + name);
 
-    if (ports != null)
-    {
-      Iterator portIterator = ports.values().iterator();
+    if (ports != null) {
+      Iterator<Port> portIterator = ports.values().iterator();
 
-      while (portIterator.hasNext())
-      {
+      while (portIterator.hasNext()) {
         strBuf.append("\n" + portIterator.next());
       }
     }
 
     String superString = super.toString();
-    if(!superString.equals(""))
-    {
+    if (!superString.equals("")) {
       strBuf.append("\n");
       strBuf.append(superString);
     }
 
     return strBuf.toString();
   }
-  
+
   /**
-   * Get the list of local attribute names defined for this element in
-   * the WSDL specification.
+   * Get the list of local attribute names defined for this element in the WSDL specification.
    *
    * @return a List of Strings, one for each local attribute name
    */
-  public List getNativeAttributeNames()
-  {
+  public List<String> getNativeAttributeNames() {
     return nativeAttributeNames;
   }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPAddressImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPAddressImpl.java
@@ -77,7 +77,7 @@ public class HTTPAddressImpl implements HTTPAddress
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("HTTPAddress (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPAddressSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPAddressSerializer.java
@@ -16,73 +16,42 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPAddressSerializer implements ExtensionSerializer,
-                                              ExtensionDeserializer,
-                                              Serializable
-{
+public class HTTPAddressSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    HTTPAddress httpAddress = (HTTPAddress)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPAddress httpAddress = (HTTPAddress) extension;
 
-    if (httpAddress != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP,
-                                   "address",
-                                   def);
+    if (httpAddress != null) {
+      String tagName = DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP, "address", def);
 
       pw.print("      <" + tagName);
 
-      DOMUtils.printAttribute(Constants.ATTR_LOCATION,
-                              httpAddress.getLocationURI(),
-                              pw);
+      DOMUtils.printAttribute(Constants.ATTR_LOCATION, httpAddress.getLocationURI(), pw);
 
       Boolean required = httpAddress.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    HTTPAddress httpAddress = (HTTPAddress)extReg.createExtension(parentType,
-                                                                  elementType);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPAddress httpAddress = (HTTPAddress) extReg.createExtension(parentType, elementType);
     String locationURI = DOMUtils.getAttribute(el, Constants.ATTR_LOCATION);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (locationURI != null)
-    {
+    if (locationURI != null) {
       httpAddress.setLocationURI(locationURI);
     }
 
-    if (requiredStr != null)
-    {
-      httpAddress.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      httpAddress.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return httpAddress;
-	}
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPBindingImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPBindingImpl.java
@@ -10,8 +10,7 @@ import javax.xml.namespace.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPBindingImpl implements HTTPBinding
-{
+public class HTTPBindingImpl implements HTTPBinding {
   protected QName elementType = HTTPConstants.Q_ELEM_HTTP_BINDING;
   // Uses the wrapper type so we can tell if it was set or not.
   protected Boolean required = null;
@@ -22,10 +21,10 @@ public class HTTPBindingImpl implements HTTPBinding
   /**
    * Set the type of this extensibility element.
    *
-   * @param elementType the type
+   * @param elementType
+   *          the type
    */
-  public void setElementType(QName elementType)
-  {
+  public void setElementType(QName elementType) {
     this.elementType = elementType;
   }
 
@@ -34,56 +33,48 @@ public class HTTPBindingImpl implements HTTPBinding
    *
    * @return the extensibility element's type
    */
-  public QName getElementType()
-  {
+  public QName getElementType() {
     return elementType;
   }
 
   /**
-   * Set whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Set whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public void setRequired(Boolean required)
-  {
+  public void setRequired(Boolean required) {
     this.required = required;
   }
 
   /**
-   * Get whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Get whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public Boolean getRequired()
-  {
+  public Boolean getRequired() {
     return required;
   }
 
   /**
    * Set the verb for this HTTP binding.
    *
-   * @param verb the desired verb
+   * @param verb
+   *          the desired verb
    */
-  public void setVerb(String verb)
-  {
+  public void setVerb(String verb) {
     this.verb = verb;
   }
 
   /**
    * Get the verb for this HTTP binding.
    */
-  public String getVerb()
-  {
+  public String getVerb() {
     return verb;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("HTTPBinding (" + elementType + "):");
     strBuf.append("\nrequired=" + required);
 
-    if (verb != null)
-    {
+    if (verb != null) {
       strBuf.append("\nverb=" + verb);
     }
 

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPBindingSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPBindingSerializer.java
@@ -16,73 +16,42 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPBindingSerializer implements ExtensionSerializer,
-                                              ExtensionDeserializer,
-                                              Serializable
-{
+public class HTTPBindingSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    HTTPBinding httpBinding = (HTTPBinding)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPBinding httpBinding = (HTTPBinding) extension;
 
-    if (httpBinding != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP,
-                                   "binding",
-                                   def);
+    if (httpBinding != null) {
+      String tagName = DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP, "binding", def);
 
       pw.print("    <" + tagName);
 
-      DOMUtils.printAttribute(HTTPConstants.ATTR_VERB,
-                              httpBinding.getVerb(),
-                              pw);
+      DOMUtils.printAttribute(HTTPConstants.ATTR_VERB, httpBinding.getVerb(), pw);
 
       Boolean required = httpBinding.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    HTTPBinding httpBinding = (HTTPBinding)extReg.createExtension(parentType,
-                                                                  elementType);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPBinding httpBinding = (HTTPBinding) extReg.createExtension(parentType, elementType);
     String verb = DOMUtils.getAttribute(el, HTTPConstants.ATTR_VERB);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (verb != null)
-    {
+    if (verb != null) {
       httpBinding.setVerb(verb);
     }
 
-    if (requiredStr != null)
-    {
-      httpBinding.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      httpBinding.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return httpBinding;
-	}
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPConstants.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPConstants.java
@@ -10,11 +10,9 @@ import com.ibm.wsdl.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPConstants
-{
+public class HTTPConstants {
   // Namespace URIs.
-  public static final String NS_URI_HTTP =
-    "http://schemas.xmlsoap.org/wsdl/http/";
+  public static final String NS_URI_HTTP = "http://schemas.xmlsoap.org/wsdl/http/";
 
   // Element names.
   public static final String ELEM_ADDRESS = "address";
@@ -22,17 +20,15 @@ public class HTTPConstants
   public static final String ELEM_URL_REPLACEMENT = "urlReplacement";
 
   // Qualified element names.
-  public static final QName Q_ELEM_HTTP_BINDING =
-    new QName(NS_URI_HTTP, Constants.ELEM_BINDING);
-  public static final QName Q_ELEM_HTTP_OPERATION =
-    new QName(NS_URI_HTTP, Constants.ELEM_OPERATION);
-  public static final QName Q_ELEM_HTTP_ADDRESS =
-    new QName(NS_URI_HTTP, ELEM_ADDRESS);
-  public static final QName Q_ELEM_HTTP_URL_ENCODED =
-    new QName(NS_URI_HTTP, ELEM_URL_ENCODED);
-  public static final QName Q_ELEM_HTTP_URL_REPLACEMENT =
-    new QName(NS_URI_HTTP, ELEM_URL_REPLACEMENT);
+  public static final QName Q_ELEM_HTTP_BINDING = new QName(NS_URI_HTTP, Constants.ELEM_BINDING);
+  public static final QName Q_ELEM_HTTP_OPERATION = new QName(NS_URI_HTTP, Constants.ELEM_OPERATION);
+  public static final QName Q_ELEM_HTTP_ADDRESS = new QName(NS_URI_HTTP, ELEM_ADDRESS);
+  public static final QName Q_ELEM_HTTP_URL_ENCODED = new QName(NS_URI_HTTP, ELEM_URL_ENCODED);
+  public static final QName Q_ELEM_HTTP_URL_REPLACEMENT = new QName(NS_URI_HTTP, ELEM_URL_REPLACEMENT);
 
   // Attribute names.
   public static final String ATTR_VERB = "verb";
+
+  private HTTPConstants() {
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPOperationImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPOperationImpl.java
@@ -10,8 +10,7 @@ import javax.xml.namespace.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPOperationImpl implements HTTPOperation
-{
+public class HTTPOperationImpl implements HTTPOperation {
   protected QName elementType = HTTPConstants.Q_ELEM_HTTP_OPERATION;
   // Uses the wrapper type so we can tell if it was set or not.
   protected Boolean required = null;
@@ -22,10 +21,10 @@ public class HTTPOperationImpl implements HTTPOperation
   /**
    * Set the type of this extensibility element.
    *
-   * @param elementType the type
+   * @param elementType
+   *          the type
    */
-  public void setElementType(QName elementType)
-  {
+  public void setElementType(QName elementType) {
     this.elementType = elementType;
   }
 
@@ -34,56 +33,48 @@ public class HTTPOperationImpl implements HTTPOperation
    *
    * @return the extensibility element's type
    */
-  public QName getElementType()
-  {
+  public QName getElementType() {
     return elementType;
   }
 
   /**
-   * Set whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Set whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public void setRequired(Boolean required)
-  {
+  public void setRequired(Boolean required) {
     this.required = required;
   }
 
   /**
-   * Get whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Get whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public Boolean getRequired()
-  {
+  public Boolean getRequired() {
     return required;
   }
 
   /**
    * Set the location URI for this HTTP operation.
    *
-   * @param locationURI the desired location URI
+   * @param locationURI
+   *          the desired location URI
    */
-  public void setLocationURI(String locationURI)
-  {
+  public void setLocationURI(String locationURI) {
     this.locationURI = locationURI;
   }
 
   /**
    * Get the location URI for this HTTP operation.
    */
-  public String getLocationURI()
-  {
+  public String getLocationURI() {
     return locationURI;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("HTTPOperation (" + elementType + "):");
     strBuf.append("\nrequired=" + required);
 
-    if (locationURI != null)
-    {
+    if (locationURI != null) {
       strBuf.append("\nlocationURI=" + locationURI);
     }
 

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPOperationSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPOperationSerializer.java
@@ -16,73 +16,42 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPOperationSerializer implements ExtensionSerializer,
-                                                ExtensionDeserializer,
-                                                Serializable
-{
+public class HTTPOperationSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    HTTPOperation httpOperation = (HTTPOperation)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPOperation httpOperation = (HTTPOperation) extension;
 
-    if (httpOperation != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP,
-                                   "operation",
-                                   def);
+    if (httpOperation != null) {
+      String tagName = DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP, "operation", def);
 
       pw.print("      <" + tagName);
 
-      DOMUtils.printAttribute(Constants.ATTR_LOCATION,
-                              httpOperation.getLocationURI(),
-                              pw);
+      DOMUtils.printAttribute(Constants.ATTR_LOCATION, httpOperation.getLocationURI(), pw);
 
       Boolean required = httpOperation.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    HTTPOperation httpOperation =
-      (HTTPOperation)extReg.createExtension(parentType, elementType);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPOperation httpOperation = (HTTPOperation) extReg.createExtension(parentType, elementType);
     String locationURI = DOMUtils.getAttribute(el, Constants.ATTR_LOCATION);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (locationURI != null)
-    {
+    if (locationURI != null) {
       httpOperation.setLocationURI(locationURI);
     }
 
-    if (requiredStr != null)
-    {
-      httpOperation.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      httpOperation.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return httpOperation;
-	}
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlEncodedImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlEncodedImpl.java
@@ -58,7 +58,7 @@ public class HTTPUrlEncodedImpl implements HTTPUrlEncoded
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("HTTPUrlEncoded (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlEncodedSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlEncodedSerializer.java
@@ -16,63 +16,35 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPUrlEncodedSerializer implements ExtensionSerializer,
-                                                 ExtensionDeserializer,
-                                                 Serializable
-{
+public class HTTPUrlEncodedSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    HTTPUrlEncoded httpUrlEncoded = (HTTPUrlEncoded)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPUrlEncoded httpUrlEncoded = (HTTPUrlEncoded) extension;
 
-    if (httpUrlEncoded != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP,
-                                   "urlEncoded",
-                                   def);
+    if (httpUrlEncoded != null) {
+      String tagName = DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP, "urlEncoded", def);
 
       pw.print("        <" + tagName);
 
       Boolean required = httpUrlEncoded.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    HTTPUrlEncoded httpUrlEncoded =
-      (HTTPUrlEncoded)extReg.createExtension(parentType, elementType);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPUrlEncoded httpUrlEncoded = (HTTPUrlEncoded) extReg.createExtension(parentType, elementType);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (requiredStr != null)
-    {
-      httpUrlEncoded.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      httpUrlEncoded.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return httpUrlEncoded;
-	}
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlReplacementImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlReplacementImpl.java
@@ -58,7 +58,7 @@ public class HTTPUrlReplacementImpl implements HTTPUrlReplacement
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("HTTPUrlReplacement (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlReplacementSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/http/HTTPUrlReplacementSerializer.java
@@ -16,63 +16,35 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class HTTPUrlReplacementSerializer implements ExtensionSerializer,
-                                                     ExtensionDeserializer,
-                                                     Serializable
-{
+public class HTTPUrlReplacementSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    HTTPUrlReplacement httpUrlReplacement = (HTTPUrlReplacement)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPUrlReplacement httpUrlReplacement = (HTTPUrlReplacement) extension;
 
-    if (httpUrlReplacement != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP,
-                                   "urlReplacement",
-                                   def);
+    if (httpUrlReplacement != null) {
+      String tagName = DOMUtils.getQualifiedValue(HTTPConstants.NS_URI_HTTP, "urlReplacement", def);
 
       pw.print("        <" + tagName);
 
       Boolean required = httpUrlReplacement.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    HTTPUrlReplacement httpUrlReplacement =
-      (HTTPUrlReplacement)extReg.createExtension(parentType, elementType);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    HTTPUrlReplacement httpUrlReplacement = (HTTPUrlReplacement) extReg.createExtension(parentType, elementType);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (requiredStr != null)
-    {
-      httpUrlReplacement.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      httpUrlReplacement.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return httpUrlReplacement;
-	}
+  }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEConstants.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEConstants.java
@@ -33,4 +33,6 @@ public class MIMEConstants
 
   // Attribute names.
   public static final String ATTR_PART = "part";
+
+  private MIMEConstants() {}
 }

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEContentImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEContentImpl.java
@@ -96,7 +96,7 @@ public class MIMEContentImpl implements MIMEContent
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("MIMEContent (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEContentSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEContentSerializer.java
@@ -22,7 +22,7 @@ public class MIMEContentSerializer implements ExtensionSerializer,
 {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
+  public void marshall(Class<?> parentType,
                        QName elementType,
                        ExtensibilityElement extension,
                        PrintWriter pw,
@@ -68,7 +68,7 @@ public class MIMEContentSerializer implements ExtensionSerializer,
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
+  public ExtensibilityElement unmarshall(Class<?> parentType,
                                          QName elementType,
                                          Element el,
                                          Definition def,
@@ -83,19 +83,16 @@ public class MIMEContentSerializer implements ExtensionSerializer,
                                                  Constants.NS_URI_WSDL,
                                                  Constants.ATTR_REQUIRED);
 
-    if (part != null)
-    {
+    if (part != null) {
       mimeContent.setPart(part);
     }
 
-    if (type != null)
-    {
+    if (type != null) {
       mimeContent.setType(type);
     }
 
-    if (requiredStr != null)
-    {
-      mimeContent.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      mimeContent.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return mimeContent;

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMimeXmlImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMimeXmlImpl.java
@@ -10,8 +10,7 @@ import javax.xml.namespace.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class MIMEMimeXmlImpl implements MIMEMimeXml
-{
+public class MIMEMimeXmlImpl implements MIMEMimeXml {
   protected QName elementType = MIMEConstants.Q_ELEM_MIME_MIME_XML;
   // Uses the wrapper type so we can tell if it was set or not.
   protected Boolean required = null;
@@ -22,10 +21,10 @@ public class MIMEMimeXmlImpl implements MIMEMimeXml
   /**
    * Set the type of this extensibility element.
    *
-   * @param elementType the type
+   * @param elementType
+   *          the type
    */
-  public void setElementType(QName elementType)
-  {
+  public void setElementType(QName elementType) {
     this.elementType = elementType;
   }
 
@@ -34,56 +33,48 @@ public class MIMEMimeXmlImpl implements MIMEMimeXml
    *
    * @return the extensibility element's type
    */
-  public QName getElementType()
-  {
+  public QName getElementType() {
     return elementType;
   }
 
   /**
-   * Set whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Set whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public void setRequired(Boolean required)
-  {
+  public void setRequired(Boolean required) {
     this.required = required;
   }
 
   /**
-   * Get whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Get whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public Boolean getRequired()
-  {
+  public Boolean getRequired() {
     return required;
   }
 
   /**
    * Set the part for this MIME mimeXml.
    *
-   * @param part the desired part
+   * @param part
+   *          the desired part
    */
-  public void setPart(String part)
-  {
+  public void setPart(String part) {
     this.part = part;
   }
 
   /**
    * Get the part for this MIME mimeXml.
    */
-  public String getPart()
-  {
+  public String getPart() {
     return part;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("MIMEMimeXml (" + elementType + "):");
     strBuf.append("\nrequired=" + required);
 
-    if (part != null)
-    {
+    if (part != null) {
       strBuf.append("\npart=" + part);
     }
 

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMimeXmlSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMimeXmlSerializer.java
@@ -22,7 +22,7 @@ public class MIMEMimeXmlSerializer implements ExtensionSerializer,
 {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
+  public void marshall(Class<?> parentType,
                        QName elementType,
                        ExtensibilityElement extension,
                        PrintWriter pw,
@@ -65,7 +65,7 @@ public class MIMEMimeXmlSerializer implements ExtensionSerializer,
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
+  public ExtensibilityElement unmarshall(Class<?> parentType,
                                          QName elementType,
                                          Element el,
                                          Definition def,
@@ -79,14 +79,12 @@ public class MIMEMimeXmlSerializer implements ExtensionSerializer,
                                                  Constants.NS_URI_WSDL,
                                                  Constants.ATTR_REQUIRED);
 
-    if (part != null)
-    {
+    if (part != null) {
       mimeMimeXml.setPart(part);
     }
 
-    if (requiredStr != null)
-    {
-      mimeMimeXml.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      mimeMimeXml.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return mimeMimeXml;

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMultipartRelatedImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMultipartRelatedImpl.java
@@ -16,7 +16,7 @@ public class MIMEMultipartRelatedImpl implements MIMEMultipartRelated
   protected QName elementType = MIMEConstants.Q_ELEM_MIME_MULTIPART_RELATED;
   // Uses the wrapper type so we can tell if it was set or not.
   protected Boolean required = null;
-  protected List mimeParts = new Vector();
+  protected List<MIMEPart> mimeParts = new ArrayList<>();
 
   public static final long serialVersionUID = 1;
 
@@ -85,24 +85,21 @@ public class MIMEMultipartRelatedImpl implements MIMEMultipartRelated
   /**
    * Get all the MIME parts defined here.
    */
-  public List getMIMEParts()
+  public List<MIMEPart> getMIMEParts()
   {
     return mimeParts;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("MIMEMultipartRelated (" + elementType + "):");
     strBuf.append("\nrequired=" + required);
 
-    if (mimeParts != null)
-    {
-      Iterator mimePartIterator = mimeParts.iterator();
+    if (mimeParts != null) {
+      Iterator<MIMEPart> mimePartIterator = mimeParts.iterator();
 
-      while (mimePartIterator.hasNext())
-      {
+      while (mimePartIterator.hasNext()) {
         strBuf.append("\n" + mimePartIterator.next());
       }
     }

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMultipartRelatedSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEMultipartRelatedSerializer.java
@@ -17,33 +17,16 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class MIMEMultipartRelatedSerializer implements ExtensionSerializer,
-                                                       ExtensionDeserializer,
-                                                       Serializable
-{
+public class MIMEMultipartRelatedSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    MIMEMultipartRelated mimeMultipartRelated =
-      (MIMEMultipartRelated)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    MIMEMultipartRelated mimeMultipartRelated = (MIMEMultipartRelated) extension;
 
-    if (mimeMultipartRelated != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(MIMEConstants.NS_URI_MIME,
-                                   "multipartRelated",
-                                   def);
+    if (mimeMultipartRelated != null) {
+      String tagName = DOMUtils.getQualifiedValue(MIMEConstants.NS_URI_MIME, "multipartRelated", def);
 
-      if (parentType != null
-          && MIMEPart.class.isAssignableFrom(parentType))
-      {
+      if (parentType != null && MIMEPart.class.isAssignableFrom(parentType)) {
         pw.print("    ");
       }
 
@@ -51,21 +34,15 @@ public class MIMEMultipartRelatedSerializer implements ExtensionSerializer,
 
       Boolean required = mimeMultipartRelated.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println('>');
 
       printMIMEParts(mimeMultipartRelated.getMIMEParts(), pw, def, extReg);
 
-      if (parentType != null
-          && MIMEPart.class.isAssignableFrom(parentType))
-      {
+      if (parentType != null && MIMEPart.class.isAssignableFrom(parentType)) {
         pw.print("    ");
       }
 
@@ -73,147 +50,88 @@ public class MIMEMultipartRelatedSerializer implements ExtensionSerializer,
     }
   }
 
-  private void printMIMEParts(List mimeParts,
-                              PrintWriter pw,
-                              Definition def,
-                              ExtensionRegistry extReg)
-                                throws WSDLException
-  {
-    if (mimeParts != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(MIMEConstants.NS_URI_MIME,
-                                   "part",
-                                   def);
-      Iterator mimePartIterator = mimeParts.iterator();
+  private void printMIMEParts(List<MIMEPart> mimeParts, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    if (mimeParts == null || mimeParts.isEmpty()) {
+      return;
+    }
 
-      while (mimePartIterator.hasNext())
-      {
-        MIMEPart mimePart = (MIMEPart)mimePartIterator.next();
+    String tagName = DOMUtils.getQualifiedValue(MIMEConstants.NS_URI_MIME, "part", def);
+    Iterator<MIMEPart> mimePartIterator = mimeParts.iterator();
 
-        if (mimePart != null)
-        {
-          pw.print("          <" + tagName);
+    while (mimePartIterator.hasNext()) {
+      MIMEPart mimePart = mimePartIterator.next();
 
-          Boolean required = mimePart.getRequired();
+      if (mimePart != null) {
+        pw.print("          <" + tagName);
 
-          if (required != null)
-          {
-            DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                             required.toString(),
-                                             def,
-                                             pw);
-          }
+        Boolean required = mimePart.getRequired();
 
-          pw.println('>');
-
-          List extensibilityElements = mimePart.getExtensibilityElements();
-
-          if (extensibilityElements != null)
-          {
-            Iterator extensibilityElementIterator =
-              extensibilityElements.iterator();
-
-            while (extensibilityElementIterator.hasNext())
-            {
-              ExtensibilityElement ext =
-                (ExtensibilityElement)extensibilityElementIterator.next();
-              QName elementType = ext.getElementType();
-              ExtensionSerializer extSer =
-                extReg.querySerializer(MIMEPart.class, elementType);
-
-              extSer.marshall(MIMEPart.class,
-                              elementType,
-                              ext,
-                              pw,
-                              def,
-                              extReg);
-            }
-          }
-
-          pw.println("          </" + tagName + '>');
+        if (required != null) {
+          DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
         }
+
+        pw.println('>');
+
+        List<ExtensibilityElement> extensibilityElements = mimePart.getExtensibilityElements();
+
+        if (extensibilityElements != null) {
+          Iterator<ExtensibilityElement> extensibilityElementIterator = extensibilityElements.iterator();
+
+          while (extensibilityElementIterator.hasNext()) {
+            ExtensibilityElement ext = extensibilityElementIterator.next();
+            QName elementType = ext.getElementType();
+            ExtensionSerializer extSer = extReg.querySerializer(MIMEPart.class, elementType);
+
+            extSer.marshall(MIMEPart.class, elementType, ext, pw, def, extReg);
+          }
+        }
+
+        pw.println("          </" + tagName + '>');
       }
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-	{
-    MIMEMultipartRelated mimeMultipartRelated =
-      (MIMEMultipartRelated)extReg.createExtension(parentType, elementType);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    MIMEMultipartRelated mimeMultipartRelated = (MIMEMultipartRelated) extReg.createExtension(parentType, elementType);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
     Element tempEl = DOMUtils.getFirstChildElement(el);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(MIMEConstants.Q_ELEM_MIME_PART, tempEl))
-      {
-        mimeMultipartRelated.addMIMEPart(
-          parseMIMEPart(MIMEMultipartRelated.class,
-                        MIMEConstants.Q_ELEM_MIME_PART,
-                        tempEl,
-                        def,
-                        extReg));
-      }
-      else
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(MIMEConstants.Q_ELEM_MIME_PART, tempEl)) {
+        mimeMultipartRelated.addMIMEPart(parseMIMEPart(MIMEMultipartRelated.class, MIMEConstants.Q_ELEM_MIME_PART, tempEl, def, extReg));
+      } else {
         DOMUtils.throwWSDLException(tempEl);
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
-    if (requiredStr != null)
-    {
-      mimeMultipartRelated.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      mimeMultipartRelated.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return mimeMultipartRelated;
-	}
+  }
 
-  private MIMEPart parseMIMEPart(Class parentType,
-                                 QName elementType,
-                                 Element el,
-                                 Definition def,
-                                 ExtensionRegistry extReg)
-                                   throws WSDLException
-  {
-    MIMEPart mimePart = (MIMEPart)extReg.createExtension(parentType,
-                                                         elementType);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+  private MIMEPart parseMIMEPart(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    MIMEPart mimePart = (MIMEPart) extReg.createExtension(parentType, elementType);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (requiredStr != null)
-    {
-      mimePart.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      mimePart.setRequired(Boolean.valueOf(requiredStr));
     }
 
     Element tempEl = DOMUtils.getFirstChildElement(el);
 
-    while (tempEl != null)
-    {
-      try
-      {
+    while (tempEl != null) {
+      try {
         QName tempElType = QNameUtils.newQName(tempEl);
-        ExtensionDeserializer extDS = extReg.queryDeserializer(MIMEPart.class,
-                                                               tempElType);
-        ExtensibilityElement ext =
-          extDS.unmarshall(MIMEPart.class, tempElType, tempEl, def, extReg);
+        ExtensionDeserializer extDS = extReg.queryDeserializer(MIMEPart.class, tempElType);
+        ExtensibilityElement ext = extDS.unmarshall(MIMEPart.class, tempElType, tempEl, def, extReg);
 
         mimePart.addExtensibilityElement(ext);
-      }
-      catch (WSDLException e)
-      {
-        if (e.getLocation() == null)
-        {
+      } catch (WSDLException e) {
+        if (e.getLocation() == null) {
           e.setLocation(XPathUtils.getXPathExprFromNode(tempEl));
         }
 

--- a/src/main/java/com/ibm/wsdl/extensions/mime/MIMEPartImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/mime/MIMEPartImpl.java
@@ -12,22 +12,21 @@ import javax.xml.namespace.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class MIMEPartImpl implements MIMEPart
-{
+public class MIMEPartImpl implements MIMEPart {
   protected QName elementType = MIMEConstants.Q_ELEM_MIME_PART;
   // Uses the wrapper type so we can tell if it was set or not.
   protected Boolean required = null;
-  protected List extElements = new Vector();
+  protected List<ExtensibilityElement> extElements = new ArrayList<>();
 
   public static final long serialVersionUID = 1;
 
   /**
    * Set the type of this extensibility element.
    *
-   * @param elementType the type
+   * @param elementType
+   *          the type
    */
-  public void setElementType(QName elementType)
-  {
+  public void setElementType(QName elementType) {
     this.elementType = elementType;
   }
 
@@ -36,49 +35,43 @@ public class MIMEPartImpl implements MIMEPart
    *
    * @return the extensibility element's type
    */
-  public QName getElementType()
-  {
+  public QName getElementType() {
     return elementType;
   }
 
   /**
-   * Set whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Set whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public void setRequired(Boolean required)
-  {
+  public void setRequired(Boolean required) {
     this.required = required;
   }
 
   /**
-   * Get whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Get whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public Boolean getRequired()
-  {
+  public Boolean getRequired() {
     return required;
   }
 
   /**
-   * Add an extensibility element. This is where the MIME
-   * elements go.
+   * Add an extensibility element. This is where the MIME elements go.
    *
-   * @param extElement the extensibility element to be added
+   * @param extElement
+   *          the extensibility element to be added
    */
-  public void addExtensibilityElement(ExtensibilityElement extElement)
-  {
+  public void addExtensibilityElement(ExtensibilityElement extElement) {
     extElements.add(extElement);
   }
-  
+
   /**
    * Remove an extensibility element.
    *
-   * @param extElement the extensibility element to be removed
+   * @param extElement
+   *          the extensibility element to be removed
    * @return the extensibility element which was removed
    */
-  public ExtensibilityElement removeExtensibilityElement(ExtensibilityElement extElement)
-  {
-    if(extElements.remove(extElement))
+  public ExtensibilityElement removeExtensibilityElement(ExtensibilityElement extElement) {
+    if (extElements.remove(extElement))
       return extElement;
     else
       return null;
@@ -87,24 +80,20 @@ public class MIMEPartImpl implements MIMEPart
   /**
    * Get all the extensibility elements defined here.
    */
-  public List getExtensibilityElements()
-  {
+  public List<ExtensibilityElement> getExtensibilityElements() {
     return extElements;
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("MIMEPart (" + elementType + "):");
     strBuf.append("\nrequired=" + required);
 
-    if (extElements != null)
-    {
-      Iterator extIterator = extElements.iterator();
+    if (extElements != null) {
+      Iterator<ExtensibilityElement> extIterator = extElements.iterator();
 
-      while (extIterator.hasNext())
-      {
+      while (extIterator.hasNext()) {
         strBuf.append("\n" + extIterator.next());
       }
     }

--- a/src/main/java/com/ibm/wsdl/extensions/schema/SchemaConstants.java
+++ b/src/main/java/com/ibm/wsdl/extensions/schema/SchemaConstants.java
@@ -40,7 +40,7 @@ public class SchemaConstants {
         new QName(NS_URI_XSD_2000, ELEM_SCHEMA);
     public static final QName Q_ELEM_XSD_2001 =
         new QName(NS_URI_XSD_2001, ELEM_SCHEMA);
-    public static final List XSD_QNAME_LIST = Arrays.asList(Q_ELEM_XSD_1999, Q_ELEM_XSD_2000, Q_ELEM_XSD_2001);
+    public static final List<QName> XSD_QNAME_LIST = Arrays.asList(Q_ELEM_XSD_1999, Q_ELEM_XSD_2000, Q_ELEM_XSD_2001);
     
     //Schema import qnames
     public static final QName Q_ELEM_IMPORT_XSD_1999 = new QName(
@@ -49,7 +49,7 @@ public class SchemaConstants {
         NS_URI_XSD_2000, Constants.ELEM_IMPORT);
     public static final QName Q_ELEM_IMPORT_XSD_2001 = new QName(
         NS_URI_XSD_2001, Constants.ELEM_IMPORT);
-    public static final List XSD_IMPORT_QNAME_LIST = Arrays.asList(Q_ELEM_IMPORT_XSD_1999, Q_ELEM_IMPORT_XSD_2000, Q_ELEM_IMPORT_XSD_2001);
+    public static final List<QName> XSD_IMPORT_QNAME_LIST = Arrays.asList(Q_ELEM_IMPORT_XSD_1999, Q_ELEM_IMPORT_XSD_2000, Q_ELEM_IMPORT_XSD_2001);
 
 
     //Schema include qnames
@@ -59,7 +59,7 @@ public class SchemaConstants {
         NS_URI_XSD_2000, ELEM_INCLUDE);
     public static final QName Q_ELEM_INCLUDE_XSD_2001 = new QName(
         NS_URI_XSD_2001, ELEM_INCLUDE);
-    public static final List XSD_INCLUDE_QNAME_LIST = Arrays.asList(Q_ELEM_INCLUDE_XSD_1999, Q_ELEM_INCLUDE_XSD_2000, Q_ELEM_INCLUDE_XSD_2001);
+    public static final List<QName> XSD_INCLUDE_QNAME_LIST = Arrays.asList(Q_ELEM_INCLUDE_XSD_1999, Q_ELEM_INCLUDE_XSD_2000, Q_ELEM_INCLUDE_XSD_2001);
 
     //Schema redefine qnames
     public static final QName Q_ELEM_REDEFINE_XSD_1999 = new QName(
@@ -68,7 +68,8 @@ public class SchemaConstants {
         NS_URI_XSD_2000, ELEM_REDEFINE);
     public static final QName Q_ELEM_REDEFINE_XSD_2001 = new QName(
 	    NS_URI_XSD_2001, ELEM_REDEFINE);
-    public static final List XSD_REDEFINE_QNAME_LIST = Arrays.asList(Q_ELEM_REDEFINE_XSD_1999, Q_ELEM_REDEFINE_XSD_2000, Q_ELEM_REDEFINE_XSD_2001);
+    public static final List<QName> XSD_REDEFINE_QNAME_LIST = Arrays.asList(Q_ELEM_REDEFINE_XSD_1999, Q_ELEM_REDEFINE_XSD_2000, Q_ELEM_REDEFINE_XSD_2001);
 
-
+    private SchemaConstants() {
+    }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/schema/SchemaImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/schema/SchemaImpl.java
@@ -4,71 +4,55 @@
 
 package com.ibm.wsdl.extensions.schema;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
-
 import javax.wsdl.extensions.schema.Schema;
 import javax.wsdl.extensions.schema.SchemaImport;
 import javax.wsdl.extensions.schema.SchemaReference;
-
 import javax.xml.namespace.QName;
-
 import org.w3c.dom.Element;
 
 /**
- * This class is used to wrap schema elements. It holds the DOM Element to the
- * <code>&lt;schema&gt;</code> element.
+ * This class is used to wrap schema elements. It holds the DOM Element to the <code>&lt;schema&gt;</code> element.
  * 
  * @see SchemaSerializer
  * @see SchemaDeserializer
  * 
  * @author Jeremy Hughes <hughesj@uk.ibm.com>
  */
-public class SchemaImpl implements Schema
-{
-  protected QName elementType = null;
+public class SchemaImpl implements Schema {
+  private QName elementType = null;
   // Uses the wrapper type so we can tell if it was set or not.
-  protected Boolean required = null;
-  protected Element element = null;
+  private Boolean required = null;
+  private Element element = null;
 
   public static final long serialVersionUID = 1;
 
   /*
-   * imports is a Map of Lists with key of the import's namespace URI. Each List
-   * contains the SchemaImport objects for that namespace. There can be more
-   * than one SchemaImport in a List - one for each schemaLocation attribute
-   * setting.
+   * imports is a Map of Lists with key of the import's namespace URI. Each List contains the SchemaImport objects for that namespace. There can be more than one SchemaImport in a List - one for each schemaLocation attribute setting.
    */
-  private Map imports = new HashMap();
+  private Map<String, List<SchemaImport>> imports = new HashMap<>();
 
   /*
-   * includes is a List of Include objects for the targetNamespace of the
-   * enclosing schema. There is one Include in the List for each <include>
-   * element in the XML Schema.
+   * includes is a List of Include objects for the targetNamespace of the enclosing schema. There is one Include in the List for each <include> element in the XML Schema.
    */
-  private List includes = new Vector();
+  private List<SchemaReference> includes = new ArrayList<>();
 
   /*
-   * redefines is a list of Redefine obejcts for the targetNamespace of the
-   * enclosing schema. There is one Redefine in the List for each <redefine>
-   * element in the XML Schema.
+   * redefines is a list of Redefine obejcts for the targetNamespace of the enclosing schema. There is one Redefine in the List for each <redefine> element in the XML Schema.
    */
-  private List redefines = new Vector();
+  private List<SchemaReference> redefines = new ArrayList<>();
 
   private String documentBaseURI = null;
 
   /**
-   * Get a map of lists containing all the imports defined here. The map's keys
-   * are Strings representing the namespace URIs, and the map's values are
-   * lists. There is one list for each namespace URI for which imports have been
-   * defined.
+   * Get a map of lists containing all the imports defined here. The map's keys are Strings representing the namespace URIs, and the map's values are lists. There is one list for each namespace URI for which imports have been defined.
    * 
    * @return a Map of Lists of Import instances keyed off the import's namespace
    */
-  public Map getImports()
-  {
+  public Map<String, List<SchemaImport>> getImports() {
     return this.imports;
   }
 
@@ -77,77 +61,59 @@ public class SchemaImpl implements Schema
    * 
    * @return the newly created schema import
    */
-  public SchemaImport createImport()
-  {
+  public SchemaImport createImport() {
     return new SchemaImportImpl();
   }
 
   /**
    * Add an import to this LightWeightSchema
    * 
-   * @param importSchema the import to be added
+   * @param importSchema
+   *          the import to be added
    */
-  public void addImport(SchemaImport importSchema)
-  {
+  public void addImport(SchemaImport importSchema) {
     String namespaceURI = importSchema.getNamespaceURI();
-    List importList = (List) this.imports.get(namespaceURI);
-
-    if (importList == null)
-    {
-      importList = new Vector();
-
-      this.imports.put(namespaceURI, importList);
-    }
-
+    List<SchemaImport> importList = this.imports.computeIfAbsent(namespaceURI, key -> new ArrayList<>());
     importList.add(importSchema);
   }
 
   /**
    * Get list of includes defined here.
    * 
-   * @return a List of SchemaReference instances representing the schema
-   *         includes.
+   * @return a List of SchemaReference instances representing the schema includes.
    */
 
-  public List getIncludes()
-  {
+  public List<SchemaReference> getIncludes() {
     return this.includes;
   }
 
-  public SchemaReference createInclude()
-  {
+  public SchemaReference createInclude() {
     return new SchemaReferenceImpl();
   }
 
-  public void addInclude(SchemaReference includeSchema)
-  {
+  public void addInclude(SchemaReference includeSchema) {
     this.includes.add(includeSchema);
   }
 
-  public List getRedefines()
-  {
+  public List<SchemaReference> getRedefines() {
     return this.redefines;
   }
 
-  public SchemaReference createRedefine()
-  {
+  public SchemaReference createRedefine() {
     return new SchemaReferenceImpl();
   }
 
-  public void addRedefine(SchemaReference redefineSchema)
-  {
+  public void addRedefine(SchemaReference redefineSchema) {
     this.redefines.add(redefineSchema);
   }
 
-  public String toString()
-  {
-    StringBuffer strBuf = new StringBuffer();
+  public String toString() {
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SchemaExtensibilityElement (" + this.elementType + "):");
     strBuf.append("\nrequired=" + this.required);
 
-    if (this.element != null)
-    {
+    if (this.element != null) {
       strBuf.append("\nelement=" + this.element);
     }
 
@@ -157,10 +123,10 @@ public class SchemaImpl implements Schema
   /**
    * Set the type of this extensibility element.
    *
-   * @param elementType the type
+   * @param elementType
+   *          the type
    */
-  public void setElementType(QName elementType)
-  {
+  public void setElementType(QName elementType) {
     this.elementType = elementType;
   }
 
@@ -169,36 +135,31 @@ public class SchemaImpl implements Schema
    *
    * @return the extensibility element's type
    */
-  public QName getElementType()
-  {
+  public QName getElementType() {
     return elementType;
   }
 
   /**
-   * Set whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Set whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public void setRequired(Boolean required)
-  {
+  public void setRequired(Boolean required) {
     this.required = required;
   }
 
   /**
-   * Get whether or not the semantics of this extension
-   * are required. Relates to the wsdl:required attribute.
+   * Get whether or not the semantics of this extension are required. Relates to the wsdl:required attribute.
    */
-  public Boolean getRequired()
-  {
+  public Boolean getRequired() {
     return required;
   }
 
   /**
    * Set the DOM Element that represents this schema element.
    *
-   * @param element the DOM element representing this schema
+   * @param element
+   *          the DOM element representing this schema
    */
-  public void setElement(Element element)
-  {
+  public void setElement(Element element) {
     this.element = element;
   }
 
@@ -207,20 +168,17 @@ public class SchemaImpl implements Schema
    *
    * @return the DOM element representing this schema
    */
-  public Element getElement()
-  {
+  public Element getElement() {
     return element;
   }
 
   /**
-   * Set the document base URI of this schema definition. Can be used to
-   * represent the origin of the schema, and can be exploited when resolving
-   * relative URIs (e.g. in &lt;import&gt;s).
+   * Set the document base URI of this schema definition. Can be used to represent the origin of the schema, and can be exploited when resolving relative URIs (e.g. in &lt;import&gt;s).
    * 
-   * @param documentBaseURI the document base URI of this schema
+   * @param documentBaseURI
+   *          the document base URI of this schema
    */
-  public void setDocumentBaseURI(String documentBaseURI)
-  {
+  public void setDocumentBaseURI(String documentBaseURI) {
     this.documentBaseURI = documentBaseURI;
   }
 
@@ -229,8 +187,7 @@ public class SchemaImpl implements Schema
    * 
    * @return the document base URI
    */
-  public String getDocumentBaseURI()
-  {
+  public String getDocumentBaseURI() {
     return this.documentBaseURI;
   }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/schema/SchemaReferenceImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/schema/SchemaReferenceImpl.java
@@ -10,8 +10,7 @@ import javax.wsdl.extensions.schema.SchemaReference;
 /**
  * @author Jeremy Hughes <hughesj@uk.ibm.com>
  */
-public class SchemaReferenceImpl implements SchemaReference
-{
+public class SchemaReferenceImpl implements SchemaReference {
 
   public static final long serialVersionUID = 1;
 
@@ -24,48 +23,45 @@ public class SchemaReferenceImpl implements SchemaReference
   /**
    * @return Returns the id.
    */
-  public String getId()
-  {
+  public String getId() {
     return this.id;
   }
 
   /**
-   * @param id The id to set.
+   * @param id
+   *          The id to set.
    */
-  public void setId(String id)
-  {
+  public void setId(String id) {
     this.id = id;
   }
 
   /**
    * @return Returns the schemaLocation.
    */
-  public String getSchemaLocationURI()
-  {
+  public String getSchemaLocationURI() {
     return this.schemaLocation;
   }
 
   /**
-   * @param schemaLocation The schemaLocation to set.
+   * @param schemaLocation
+   *          The schemaLocation to set.
    */
-  public void setSchemaLocationURI(String schemaLocation)
-  {
+  public void setSchemaLocationURI(String schemaLocation) {
     this.schemaLocation = schemaLocation;
   }
 
   /**
    * @return Returns the importedSchema.
    */
-  public Schema getReferencedSchema()
-  {
+  public Schema getReferencedSchema() {
     return this.referencedSchema;
   }
 
   /**
-   * @param referencedSchema The importedSchema to set.
+   * @param referencedSchema
+   *          The importedSchema to set.
    */
-  public void setReferencedSchema(Schema referencedSchema)
-  {
+  public void setReferencedSchema(Schema referencedSchema) {
     this.referencedSchema = referencedSchema;
   }
 }

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPAddressImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPAddressImpl.java
@@ -77,7 +77,7 @@ public class SOAPAddressImpl implements SOAPAddress
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SOAPAddress (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPBindingImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPBindingImpl.java
@@ -99,7 +99,7 @@ public class SOAPBindingImpl implements SOAPBinding
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SOAPBinding (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPConstants.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPConstants.java
@@ -46,4 +46,6 @@ public class SOAPConstants
   public static final String ATTR_USE = "use";
   public static final String ATTR_ENCODING_STYLE = "encodingStyle";
   public static final String ATTR_PART = "part";
+
+  private SOAPConstants() {}
 }

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPFaultSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPFaultSerializer.java
@@ -17,102 +17,58 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class SOAPFaultSerializer implements ExtensionSerializer,
-                                            ExtensionDeserializer,
-                                            Serializable
-{
+public class SOAPFaultSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    SOAPFault soapFault = (SOAPFault)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    SOAPFault soapFault = (SOAPFault) extension;
 
-    if (soapFault != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP,
-                                   "fault",
-                                   def);
+    if (soapFault != null) {
+      String tagName = DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP, "fault", def);
 
       pw.print("        <" + tagName);
 
       DOMUtils.printAttribute(Constants.ATTR_NAME, soapFault.getName(), pw);
       DOMUtils.printAttribute(SOAPConstants.ATTR_USE, soapFault.getUse(), pw);
-      DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE,
-                      StringUtils.getNMTokens(soapFault.getEncodingStyles()),
-                      pw);
-      DOMUtils.printAttribute(Constants.ATTR_NAMESPACE,
-                              soapFault.getNamespaceURI(),
-                              pw);
+      DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE, StringUtils.getNMTokens(soapFault.getEncodingStyles()), pw);
+      DOMUtils.printAttribute(Constants.ATTR_NAMESPACE, soapFault.getNamespaceURI(), pw);
 
       Boolean required = soapFault.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println("/>");
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-  {
-    SOAPFault soapFault = (SOAPFault)extReg.createExtension(parentType,
-                                                            elementType);
-    //TODO: remove unused variable, message
-    QName message = DOMUtils.getQualifiedAttributeValue(el,
-                                                    Constants.ATTR_MESSAGE,
-                                                    SOAPConstants.ELEM_HEADER,
-                                                    false,
-                                                    def);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    SOAPFault soapFault = (SOAPFault) extReg.createExtension(parentType, elementType);
     String name = DOMUtils.getAttribute(el, Constants.ATTR_NAME);
     String use = DOMUtils.getAttribute(el, SOAPConstants.ATTR_USE);
-    String encStyleStr = DOMUtils.getAttribute(el,
-                                          SOAPConstants.ATTR_ENCODING_STYLE);
-    String namespaceURI = DOMUtils.getAttribute(el,
-                                                Constants.ATTR_NAMESPACE);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String encStyleStr = DOMUtils.getAttribute(el, SOAPConstants.ATTR_ENCODING_STYLE);
+    String namespaceURI = DOMUtils.getAttribute(el, Constants.ATTR_NAMESPACE);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (name != null)
-    {
+    if (name != null) {
       soapFault.setName(name);
     }
 
-    if (use != null)
-    {
+    if (use != null) {
       soapFault.setUse(use);
     }
 
-    if (encStyleStr != null)
-    {
+    if (encStyleStr != null) {
       soapFault.setEncodingStyles(StringUtils.parseNMTokens(encStyleStr));
     }
 
-    if (namespaceURI != null)
-    {
+    if (namespaceURI != null) {
       soapFault.setNamespaceURI(namespaceURI);
     }
 
-    if (requiredStr != null)
-    {
-      soapFault.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      soapFault.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return soapFault;

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderFaultImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderFaultImpl.java
@@ -18,7 +18,7 @@ public class SOAPHeaderFaultImpl implements SOAPHeaderFault
   protected QName message = null;
   protected String part = null;
   protected String use = null;
-  protected List encodingStyles = null;
+  protected List<String> encodingStyles = null;
   protected String namespaceURI = null;
 
   public static final long serialVersionUID = 1;
@@ -120,7 +120,7 @@ public class SOAPHeaderFaultImpl implements SOAPHeaderFault
    *
    * @param encodingStyles the desired encodingStyles
    */
-  public void setEncodingStyles(List encodingStyles)
+  public void setEncodingStyles(List<String> encodingStyles)
   {
     this.encodingStyles = encodingStyles;
   }
@@ -128,7 +128,7 @@ public class SOAPHeaderFaultImpl implements SOAPHeaderFault
   /**
    * Get the encodingStyles for this SOAP header fault.
    */
-  public List getEncodingStyles()
+  public List<String> getEncodingStyles()
   {
     return encodingStyles;
   }
@@ -153,7 +153,7 @@ public class SOAPHeaderFaultImpl implements SOAPHeaderFault
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SOAPHeaderFault (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderImpl.java
@@ -18,9 +18,9 @@ public class SOAPHeaderImpl implements SOAPHeader
   protected QName message = null;
   protected String part = null;
   protected String use = null;
-  protected List encodingStyles = null;
+  protected List<String> encodingStyles = null;
   protected String namespaceURI = null;
-  protected List soapHeaderFaults = new Vector();
+  protected List<SOAPHeaderFault> soapHeaderFaults = new ArrayList<>();
 
   public static final long serialVersionUID = 1;
 
@@ -121,7 +121,7 @@ public class SOAPHeaderImpl implements SOAPHeader
    *
    * @param encodingStyles the desired encodingStyles
    */
-  public void setEncodingStyles(List encodingStyles)
+  public void setEncodingStyles(List<String> encodingStyles)
   {
     this.encodingStyles = encodingStyles;
   }
@@ -129,7 +129,7 @@ public class SOAPHeaderImpl implements SOAPHeader
   /**
    * Get the encodingStyles for this SOAP header.
    */
-  public List getEncodingStyles()
+  public List<String> getEncodingStyles()
   {
     return encodingStyles;
   }
@@ -165,14 +165,14 @@ public class SOAPHeaderImpl implements SOAPHeader
       return null;
   }
 
-  public List getSOAPHeaderFaults()
+  public List<SOAPHeaderFault> getSOAPHeaderFaults()
   {
     return soapHeaderFaults;
   }
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SOAPHeader (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderSerializer.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPHeaderSerializer.java
@@ -18,54 +18,27 @@ import com.ibm.wsdl.util.xml.*;
 /**
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class SOAPHeaderSerializer implements ExtensionSerializer,
-                                             ExtensionDeserializer,
-                                             Serializable
-{
+public class SOAPHeaderSerializer implements ExtensionSerializer, ExtensionDeserializer, Serializable {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
-                       QName elementType,
-                       ExtensibilityElement extension,
-                       PrintWriter pw,
-                       Definition def,
-                       ExtensionRegistry extReg)
-                         throws WSDLException
-  {
-    SOAPHeader soapHeader = (SOAPHeader)extension;
+  public void marshall(Class<?> parentType, QName elementType, ExtensibilityElement extension, PrintWriter pw, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    SOAPHeader soapHeader = (SOAPHeader) extension;
 
-    if (soapHeader != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP,
-                                   "header",
-                                   def);
+    if (soapHeader != null) {
+      String tagName = DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP, "header", def);
 
       pw.print("        <" + tagName);
 
-      DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE,
-                                       soapHeader.getMessage(),
-                                       def,
-                                       pw);
-      DOMUtils.printAttribute(SOAPConstants.ATTR_PART,
-                              soapHeader.getPart(),
-                              pw);
+      DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE, soapHeader.getMessage(), def, pw);
+      DOMUtils.printAttribute(SOAPConstants.ATTR_PART, soapHeader.getPart(), pw);
       DOMUtils.printAttribute(SOAPConstants.ATTR_USE, soapHeader.getUse(), pw);
-      DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE,
-                      StringUtils.getNMTokens(soapHeader.getEncodingStyles()),
-                      pw);
-      DOMUtils.printAttribute(Constants.ATTR_NAMESPACE,
-                              soapHeader.getNamespaceURI(),
-                              pw);
+      DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE, StringUtils.getNMTokens(soapHeader.getEncodingStyles()), pw);
+      DOMUtils.printAttribute(Constants.ATTR_NAMESPACE, soapHeader.getNamespaceURI(), pw);
 
       Boolean required = soapHeader.getRequired();
 
-      if (required != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                         required.toString(),
-                                         def,
-                                         pw);
+      if (required != null) {
+        DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
       }
 
       pw.println('>');
@@ -76,53 +49,27 @@ public class SOAPHeaderSerializer implements ExtensionSerializer,
     }
   }
 
-  private static void printSoapHeaderFaults(List soapHeaderFaults,
-                                            Definition def,
-                                            PrintWriter pw)
-                                              throws WSDLException
-  {
-    if (soapHeaderFaults != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP,
-                                   "headerfault",
-                                   def);
-      Iterator soapHeaderFaultIterator = soapHeaderFaults.iterator();
+  private static void printSoapHeaderFaults(List<SOAPHeaderFault> soapHeaderFaults, Definition def, PrintWriter pw) throws WSDLException {
+    if (soapHeaderFaults != null) {
+      String tagName = DOMUtils.getQualifiedValue(SOAPConstants.NS_URI_SOAP, "headerfault", def);
+      Iterator<SOAPHeaderFault> soapHeaderFaultIterator = soapHeaderFaults.iterator();
 
-      while (soapHeaderFaultIterator.hasNext())
-      {
-        SOAPHeaderFault soapHeaderFault =
-          (SOAPHeaderFault)soapHeaderFaultIterator.next();
+      while (soapHeaderFaultIterator.hasNext()) {
+        SOAPHeaderFault soapHeaderFault = soapHeaderFaultIterator.next();
 
-        if (soapHeaderFault != null)
-        {
+        if (soapHeaderFault != null) {
           pw.print("          <" + tagName);
 
-          DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE,
-                                           soapHeaderFault.getMessage(),
-                                           def,
-                                           pw);
-          DOMUtils.printAttribute(SOAPConstants.ATTR_PART,
-                                  soapHeaderFault.getPart(),
-                                  pw);
-          DOMUtils.printAttribute(SOAPConstants.ATTR_USE,
-                                  soapHeaderFault.getUse(),
-                                  pw);
-          DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE,
-                StringUtils.getNMTokens(soapHeaderFault.getEncodingStyles()),
-                pw);
-          DOMUtils.printAttribute(Constants.ATTR_NAMESPACE,
-                                  soapHeaderFault.getNamespaceURI(),
-                                  pw);
+          DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE, soapHeaderFault.getMessage(), def, pw);
+          DOMUtils.printAttribute(SOAPConstants.ATTR_PART, soapHeaderFault.getPart(), pw);
+          DOMUtils.printAttribute(SOAPConstants.ATTR_USE, soapHeaderFault.getUse(), pw);
+          DOMUtils.printAttribute(SOAPConstants.ATTR_ENCODING_STYLE, StringUtils.getNMTokens(soapHeaderFault.getEncodingStyles()), pw);
+          DOMUtils.printAttribute(Constants.ATTR_NAMESPACE, soapHeaderFault.getNamespaceURI(), pw);
 
           Boolean required = soapHeaderFault.getRequired();
 
-          if (required != null)
-          {
-            DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED,
-                                             required.toString(),
-                                             def,
-                                             pw);
+          if (required != null) {
+            DOMUtils.printQualifiedAttribute(Constants.Q_ATTR_REQUIRED, required.toString(), def, pw);
           }
 
           pw.println("/>");
@@ -131,75 +78,45 @@ public class SOAPHeaderSerializer implements ExtensionSerializer,
     }
   }
 
-  public ExtensibilityElement unmarshall(Class parentType,
-                                         QName elementType,
-                                         Element el,
-                                         Definition def,
-                                         ExtensionRegistry extReg)
-                                           throws WSDLException
-  {
-    SOAPHeader soapHeader = (SOAPHeader)extReg.createExtension(parentType,
-                                                               elementType);
-    QName message =
-      DOMUtils.getQualifiedAttributeValue(el,
-                                          Constants.ATTR_MESSAGE,
-                                          SOAPConstants.ELEM_HEADER,
-                                          false,
-                                          def);
+  public ExtensibilityElement unmarshall(Class<?> parentType, QName elementType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
+    SOAPHeader soapHeader = (SOAPHeader) extReg.createExtension(parentType, elementType);
+    QName message = DOMUtils.getQualifiedAttributeValue(el, Constants.ATTR_MESSAGE, SOAPConstants.ELEM_HEADER, false, def);
     String part = DOMUtils.getAttribute(el, SOAPConstants.ATTR_PART);
     String use = DOMUtils.getAttribute(el, SOAPConstants.ATTR_USE);
-    String encStyleStr = DOMUtils.getAttribute(el,
-                                          SOAPConstants.ATTR_ENCODING_STYLE);
+    String encStyleStr = DOMUtils.getAttribute(el, SOAPConstants.ATTR_ENCODING_STYLE);
     String namespaceURI = DOMUtils.getAttribute(el, Constants.ATTR_NAMESPACE);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (message != null)
-    {
+    if (message != null) {
       soapHeader.setMessage(message);
     }
 
-    if (part != null)
-    {
+    if (part != null) {
       soapHeader.setPart(part);
     }
 
-    if (use != null)
-    {
+    if (use != null) {
       soapHeader.setUse(use);
     }
 
-    if (encStyleStr != null)
-    {
+    if (encStyleStr != null) {
       soapHeader.setEncodingStyles(StringUtils.parseNMTokens(encStyleStr));
     }
 
-    if (namespaceURI != null)
-    {
+    if (namespaceURI != null) {
       soapHeader.setNamespaceURI(namespaceURI);
     }
 
-    if (requiredStr != null)
-    {
-      soapHeader.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      soapHeader.setRequired(Boolean.valueOf(requiredStr));
     }
 
     Element tempEl = DOMUtils.getFirstChildElement(el);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(SOAPConstants.Q_ELEM_SOAP_HEADER_FAULT, tempEl))
-      {
-        soapHeader.addSOAPHeaderFault(
-          parseSoapHeaderFault(SOAPHeader.class,
-                               SOAPConstants.Q_ELEM_SOAP_HEADER_FAULT,
-                               tempEl,
-                               extReg,
-                               def));
-      }
-      else
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(SOAPConstants.Q_ELEM_SOAP_HEADER_FAULT, tempEl)) {
+        soapHeader.addSOAPHeaderFault(parseSoapHeaderFault(SOAPHeader.class, SOAPConstants.Q_ELEM_SOAP_HEADER_FAULT, tempEl, extReg, def));
+      } else {
         DOMUtils.throwWSDLException(tempEl);
       }
 
@@ -209,59 +126,37 @@ public class SOAPHeaderSerializer implements ExtensionSerializer,
     return soapHeader;
   }
 
-  private static SOAPHeaderFault parseSoapHeaderFault(Class parentType,
-                                                      QName elementType,
-                                                      Element el,
-                                                      ExtensionRegistry extReg,
-                                                      Definition def)
-                                                        throws WSDLException
-  {
-    SOAPHeaderFault soapHeaderFault =
-      (SOAPHeaderFault)extReg.createExtension(parentType, elementType);
-    QName message =
-      DOMUtils.getQualifiedAttributeValue(el,
-                                          Constants.ATTR_MESSAGE,
-                                          SOAPConstants.ELEM_HEADER,
-                                          false,
-                                          def);
+  private static SOAPHeaderFault parseSoapHeaderFault(Class<?> parentType, QName elementType, Element el, ExtensionRegistry extReg, Definition def) throws WSDLException {
+    SOAPHeaderFault soapHeaderFault = (SOAPHeaderFault) extReg.createExtension(parentType, elementType);
+    QName message = DOMUtils.getQualifiedAttributeValue(el, Constants.ATTR_MESSAGE, SOAPConstants.ELEM_HEADER, false, def);
     String part = DOMUtils.getAttribute(el, SOAPConstants.ATTR_PART);
     String use = DOMUtils.getAttribute(el, SOAPConstants.ATTR_USE);
-    String encStyleStr = DOMUtils.getAttribute(el,
-                                          SOAPConstants.ATTR_ENCODING_STYLE);
+    String encStyleStr = DOMUtils.getAttribute(el, SOAPConstants.ATTR_ENCODING_STYLE);
     String namespaceURI = DOMUtils.getAttribute(el, Constants.ATTR_NAMESPACE);
-    String requiredStr = DOMUtils.getAttributeNS(el,
-                                                 Constants.NS_URI_WSDL,
-                                                 Constants.ATTR_REQUIRED);
+    String requiredStr = DOMUtils.getAttributeNS(el, Constants.NS_URI_WSDL, Constants.ATTR_REQUIRED);
 
-    if (message != null)
-    {
+    if (message != null) {
       soapHeaderFault.setMessage(message);
     }
 
-    if (part != null)
-    {
+    if (part != null) {
       soapHeaderFault.setPart(part);
     }
 
-    if (use != null)
-    {
+    if (use != null) {
       soapHeaderFault.setUse(use);
     }
 
-    if (encStyleStr != null)
-    {
-      soapHeaderFault.setEncodingStyles(
-        StringUtils.parseNMTokens(encStyleStr));
+    if (encStyleStr != null) {
+      soapHeaderFault.setEncodingStyles(StringUtils.parseNMTokens(encStyleStr));
     }
 
-    if (namespaceURI != null)
-    {
+    if (namespaceURI != null) {
       soapHeaderFault.setNamespaceURI(namespaceURI);
     }
 
-    if (requiredStr != null)
-    {
-      soapHeaderFault.setRequired(new Boolean(requiredStr));
+    if (requiredStr != null) {
+      soapHeaderFault.setRequired(Boolean.valueOf(requiredStr));
     }
 
     return soapHeaderFault;

--- a/src/main/java/com/ibm/wsdl/extensions/soap/SOAPOperationImpl.java
+++ b/src/main/java/com/ibm/wsdl/extensions/soap/SOAPOperationImpl.java
@@ -103,7 +103,7 @@ public class SOAPOperationImpl implements SOAPOperation
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("SOAPOperation (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/com/ibm/wsdl/util/IOUtils.java
+++ b/src/main/java/com/ibm/wsdl/util/IOUtils.java
@@ -16,6 +16,10 @@ public class IOUtils {
   // debug flag - generates debug stuff if true
   static boolean debug = false;
 
+  private IOUtils() {
+    
+  }
+
   //////////////////////////////////////////////////////////////////////////
 
   public static String getStringFromReader (Reader reader) throws IOException {

--- a/src/main/java/com/ibm/wsdl/util/StringUtils.java
+++ b/src/main/java/com/ibm/wsdl/util/StringUtils.java
@@ -12,99 +12,103 @@ import java.net.MalformedURLException;
 /**
  * Deals with strings (probably need to elaborate some more).
  *
- * @author   Matthew J. Duftler
+ * @author Matthew J. Duftler
  */
-public class StringUtils
-{
-  public static final String lineSeparator =
-    System.getProperty("line.separator", "\n");
+public class StringUtils {
+  public static final String lineSeparator = System.getProperty("line.separator", "\n");
   public static final String lineSeparatorStr = cleanString(lineSeparator);
 
+
+  private StringUtils() {
+    
+  }
   // Ensure that escape sequences are passed through properly.
-  public static String cleanString(String str)
-  {
+  public static String cleanString(String str) {
     if (str == null)
       return null;
-    else
-    {
-      char[]       charArray = str.toCharArray();
-      StringBuffer sBuf      = new StringBuffer();
-      
+    else {
+      char[] charArray = str.toCharArray();
+      StringBuilder sBuf = new StringBuilder();
+
       for (int i = 0; i < charArray.length; i++)
-        switch (charArray[i])
-        {
-          case '\"' : sBuf.append("\\\"");
-                      break;
-          case '\\' : sBuf.append("\\\\");
-                      break;
-          case '\n' : sBuf.append("\\n");
-                      break;
-          case '\r' : sBuf.append("\\r");
-                      break;
-          default   : sBuf.append(charArray[i]);
-                      break;
+        switch (charArray[i]) {
+          case '\"':
+            sBuf.append("\\\"");
+            break;
+          case '\\':
+            sBuf.append("\\\\");
+            break;
+          case '\n':
+            sBuf.append("\\n");
+            break;
+          case '\r':
+            sBuf.append("\\r");
+            break;
+          default:
+            sBuf.append(charArray[i]);
+            break;
         }
-      
+
       return sBuf.toString();
     }
   }
 
   /*
-    This method will return the correct name for a class object representing
-    a primitive, a single instance of a class, as well as n-dimensional arrays
-    of primitives or instances. This logic is needed to handle the string returned
-    from Class.getName(). If the class object represents a single instance (or
-    a primitive), Class.getName() returns the fully-qualified name of the class
-    and no further work is needed. However, if the class object represents an
-    array (of n dimensions), Class.getName() returns a Descriptor (the Descriptor
-    grammar is defined in section 4.3 of the Java VM Spec). This method will
-    parse the Descriptor if necessary.
-  */
-  public static String getClassName(Class targetClass)
-  {
+   * This method will return the correct name for a class object representing a primitive, a single instance of a class, as well as n-dimensional arrays of primitives or instances. This logic is needed to handle the string returned from Class.getName(). If the class object represents a single
+   * instance (or a primitive), Class.getName() returns the fully-qualified name of the class and no further work is needed. However, if the class object represents an array (of n dimensions), Class.getName() returns a Descriptor (the Descriptor grammar is defined in section 4.3 of the Java VM
+   * Spec). This method will parse the Descriptor if necessary.
+   */
+  public static String getClassName(Class<?> targetClass) {
     String className = targetClass.getName();
-
     return targetClass.isArray() ? parseDescriptor(className) : className;
   }
 
   /*
-    See the comment above for getClassName(targetClass)...
-  */
-  private static String parseDescriptor(String className)
-  {
+   * See the comment above for getClassName(targetClass)...
+   */
+  private static String parseDescriptor(String className) {
     char[] classNameChars = className.toCharArray();
-    int    arrayDim       = 0;
-    int    i              = 0;
+    int arrayDim = 0;
+    int i = 0;
 
-    while (classNameChars[i] == '[')
-    {
+    while (classNameChars[i] == '[') {
       arrayDim++;
       i++;
     }
 
-    StringBuffer classNameBuf = new StringBuffer();
+    StringBuilder classNameBuf = new StringBuilder();
 
-    switch (classNameChars[i++])
-    {
-      case 'B' : classNameBuf.append("byte");
-                 break;
-      case 'C' : classNameBuf.append("char");
-                 break;
-      case 'D' : classNameBuf.append("double");
-                 break;
-      case 'F' : classNameBuf.append("float");
-                 break;
-      case 'I' : classNameBuf.append("int");
-                 break;
-      case 'J' : classNameBuf.append("long");
-                 break;
-      case 'S' : classNameBuf.append("short");
-                 break;
-      case 'Z' : classNameBuf.append("boolean");
-                 break;
-      case 'L' : classNameBuf.append(classNameChars,
-                                     i, classNameChars.length - i - 1);
-                 break;
+    switch (classNameChars[i++]) {
+      case 'B':
+        classNameBuf.append("byte");
+        break;
+      case 'C':
+        classNameBuf.append("char");
+        break;
+      case 'D':
+        classNameBuf.append("double");
+        break;
+      case 'F':
+        classNameBuf.append("float");
+        break;
+      case 'I':
+        classNameBuf.append("int");
+        break;
+      case 'J':
+        classNameBuf.append("long");
+        break;
+      case 'S':
+        classNameBuf.append("short");
+        break;
+      case 'Z':
+        classNameBuf.append("boolean");
+        break;
+      case 'L':
+        classNameBuf.append(classNameChars, i, classNameChars.length - i - 1);
+        break;
+      default:
+        break;
+
     }
 
     for (i = 0; i < arrayDim; i++)
@@ -114,24 +118,17 @@ public class StringUtils
   }
 
   /*
-  @param contextURL the context in which to attempt to resolve the spec.
-  Effectively a document base.
-  */
-  public static URL getURL(URL contextURL, String spec)
-    throws MalformedURLException
-  {
-    try
-    {
+   * @param contextURL the context in which to attempt to resolve the spec. Effectively a document base.
+   */
+  public static URL getURL(URL contextURL, String spec) throws MalformedURLException {
+    try {
       return new URL(contextURL, spec);
-    }
-    catch (MalformedURLException e)
-    {
+    } catch (MalformedURLException e) {
       File tempFile = new File(spec);
-      if (contextURL == null || tempFile.isAbsolute())
-      {
+      if (contextURL == null || tempFile.isAbsolute()) {
         return tempFile.toURL();
       }
-      
+
       // only reach here if the contextURL !null, spec is relative path and
       // MalformedURLException thrown
       throw e;
@@ -139,71 +136,51 @@ public class StringUtils
   }
 
   /*
-    Returns an InputStream for reading from the specified resource, if the
-    resource points to a stream.
-  */
-  public static InputStream getContentAsInputStream(URL url)
-    throws SecurityException,
-           IllegalArgumentException,
-           IOException
-  {
-    if (url == null)
-    {
+   * Returns an InputStream for reading from the specified resource, if the resource points to a stream.
+   */
+  public static InputStream getContentAsInputStream(URL url) throws SecurityException, IllegalArgumentException, IOException {
+    if (url == null) {
       throw new IllegalArgumentException("URL cannot be null.");
     }
 
-    try
-    {
+    try {
       InputStream content = url.openStream();
 
-      if (content == null)
-      {
+      if (content == null) {
         throw new IllegalArgumentException("No content.");
       }
-        return content;
-      }
-    catch (SecurityException e)
-    {
-      throw new SecurityException("Your JVM's SecurityManager has " +
-                                  "disallowed this.");
-    }
-    catch (FileNotFoundException e)
-    {
+      return content;
+    } catch (SecurityException e) {
+      throw new SecurityException("Your JVM's SecurityManager has " + "disallowed this.");
+    } catch (FileNotFoundException e) {
       throw new FileNotFoundException("This file was not found: " + url);
     }
   }
 
-  public static List parseNMTokens(String nmTokens)
-  {
+  public static List<String> parseNMTokens(String nmTokens) {
     StringTokenizer strTok = new StringTokenizer(nmTokens, " ");
-    List tokens = new Vector();
+    List<String> tokens = new ArrayList<>();
 
-    while (strTok.hasMoreTokens())
-    {
+    while (strTok.hasMoreTokens()) {
       tokens.add(strTok.nextToken());
     }
 
     return tokens;
   }
 
-  public static String getNMTokens(List list)
-  {
-    if (list != null)
-    {
-      StringBuffer strBuf = new StringBuffer();
+  public static String getNMTokens(List<String> list) {
+    if (list != null) {
+      StringBuilder strBuf = new StringBuilder();
       int size = list.size();
 
-      for (int i = 0; i < size; i++)
-      {
-        String token = (String)list.get(i);
+      for (int i = 0; i < size; i++) {
+        String token = list.get(i);
 
         strBuf.append((i > 0 ? " " : "") + token);
       }
 
       return strBuf.toString();
-    }
-    else
-    {
+    } else {
       return null;
     }
   }

--- a/src/main/java/com/ibm/wsdl/xml/WSDLReaderImpl.java
+++ b/src/main/java/com/ibm/wsdl/xml/WSDLReaderImpl.java
@@ -15,36 +15,25 @@ import javax.wsdl.*;
 import javax.wsdl.extensions.*;
 import javax.wsdl.factory.*;
 import javax.wsdl.xml.*;
-
 import com.ibm.wsdl.*;
 import com.ibm.wsdl.util.*;
 import com.ibm.wsdl.util.xml.*;
-
 import javax.wsdl.extensions.schema.Schema;
 import javax.wsdl.extensions.schema.SchemaReference;
 import com.ibm.wsdl.extensions.schema.SchemaConstants;
 
-
 /**
- * This class describes a collection of methods
- * that enable conversion of a WSDL document (in XML,
- * following the WSDL schema described in the WSDL
- * specification) into a WSDL model.
+ * This class describes a collection of methods that enable conversion of a WSDL document (in XML, following the WSDL schema described in the WSDL specification) into a WSDL model.
  *
  * @author Matthew J. Duftler
  * @author Nirmal Mukhi
  */
-public class WSDLReaderImpl implements WSDLReader
-{
+public class WSDLReaderImpl implements WSDLReader {
   // Used for determining the style of operations.
-  private static final List STYLE_ONE_WAY =
-    Arrays.asList(Constants.ELEM_INPUT);
-  private static final List STYLE_REQUEST_RESPONSE =
-    Arrays.asList(Constants.ELEM_INPUT, Constants.ELEM_OUTPUT);
-  private static final List STYLE_SOLICIT_RESPONSE =
-    Arrays.asList(Constants.ELEM_OUTPUT, Constants.ELEM_INPUT);
-  private static final List STYLE_NOTIFICATION =
-    Arrays.asList(Constants.ELEM_OUTPUT);
+  private static final List<String> STYLE_ONE_WAY = Arrays.asList(Constants.ELEM_INPUT);
+  private static final List<String> STYLE_REQUEST_RESPONSE = Arrays.asList(Constants.ELEM_INPUT, Constants.ELEM_OUTPUT);
+  private static final List<String> STYLE_SOLICIT_RESPONSE = Arrays.asList(Constants.ELEM_OUTPUT, Constants.ELEM_INPUT);
+  private static final List<String> STYLE_NOTIFICATION = Arrays.asList(Constants.ELEM_OUTPUT);
 
   protected boolean verbose = true;
   protected boolean importDocuments = true;
@@ -53,11 +42,10 @@ public class WSDLReaderImpl implements WSDLReader
   protected String factoryImplName = null;
   protected WSDLLocator loc = null;
   protected WSDLFactory factory = null;
-  
-  //Contains all schemas used by this wsdl, either in-line or nested 
-  //via wsdl imports or schema imports, includes or redefines
+
+  // Contains all schemas used by this wsdl, either in-line or nested
+  // via wsdl imports or schema imports, includes or redefines
   protected Map allSchemas = new Hashtable();
-  
 
   /**
    * Sets the specified feature to the specified value.
@@ -65,239 +53,175 @@ public class WSDLReaderImpl implements WSDLReader
    * The supported features are:
    * <p>
    * <table border=1>
-   *   <tr>
-   *     <th>Name</th>
-   *     <th>Description</th>
-   *     <th>Default Value</th>
-   *   </tr>
-   *   <tr>
-   *     <td><center>javax.wsdl.verbose</center></td>
-   *     <td>If set to true, status messages will be displayed.</td>
-   *     <td><center>true</center></td>
-   *   </tr>
-   *   <tr>
-   *     <td><center>javax.wsdl.importDocuments</center></td>
-   *     <td>If set to true, imported WSDL documents will be
-   *         retrieved and processed.</td>
-   *     <td><center>true</center></td>
-   *   </tr>
-   *   <tr>
-   *     <td><center>com.ibm.wsdl.parseXMLSchemas</center></td>
-   *     <td>If set to true, the schema documents inlined and import directly
-   *         or indrectly will be retrieved as javax.wsdl.extensions.schema.Schema
-   *         objects and referred to in the Definition. This is the default (only)
-   *         behaviour from JWSDL 1.2. Which is why the default for this feature is true. 
-   *         However, prior to JWSDL 1.2 the only behaviour was not to parse the schema
-   *         files. Setting this feature to false will prevent the schemas being parsed.</td>
-   *     <td><center>true</center></td>
-   *   </tr>
+   * <tr>
+   * <th>Name</th>
+   * <th>Description</th>
+   * <th>Default Value</th>
+   * </tr>
+   * <tr>
+   * <td><center>javax.wsdl.verbose</center></td>
+   * <td>If set to true, status messages will be displayed.</td>
+   * <td><center>true</center></td>
+   * </tr>
+   * <tr>
+   * <td><center>javax.wsdl.importDocuments</center></td>
+   * <td>If set to true, imported WSDL documents will be retrieved and processed.</td>
+   * <td><center>true</center></td>
+   * </tr>
+   * <tr>
+   * <td><center>com.ibm.wsdl.parseXMLSchemas</center></td>
+   * <td>If set to true, the schema documents inlined and import directly or indrectly will be retrieved as javax.wsdl.extensions.schema.Schema objects and referred to in the Definition. This is the default (only) behaviour from JWSDL 1.2. Which is why the default for this feature is true. However,
+   * prior to JWSDL 1.2 the only behaviour was not to parse the schema files. Setting this feature to false will prevent the schemas being parsed.</td>
+   * <td><center>true</center></td>
+   * </tr>
    * </table>
    * <p>
-   * All feature names must be fully-qualified, Java package style. All
-   * names starting with javax.wsdl. are reserved for features defined
-   * by the JWSDL specification. It is recommended that implementation-
-   * specific features be fully-qualified to match the package name
-   * of that implementation. For example: com.abc.featureName
+   * All feature names must be fully-qualified, Java package style. All names starting with javax.wsdl. are reserved for features defined by the JWSDL specification. It is recommended that implementation- specific features be fully-qualified to match the package name of that implementation. For
+   * example: com.abc.featureName
    *
-   * @param name the name of the feature to be set.
-   * @param value the value to set the feature to.
-   * @throws IllegalArgumentException if the feature name is not recognized.
+   * @param name
+   *          the name of the feature to be set.
+   * @param value
+   *          the value to set the feature to.
+   * @throws IllegalArgumentException
+   *           if the feature name is not recognized.
    * @see #getFeature(String)
    */
-  public void setFeature(String name, boolean value)
-    throws IllegalArgumentException
-  {
-    if (name == null)
-    {
+  public void setFeature(String name, boolean value) throws IllegalArgumentException {
+    if (name == null) {
       throw new IllegalArgumentException("Feature name must not be null.");
     }
 
-    if (name.equals(Constants.FEATURE_VERBOSE))
-    {
+    if (name.equals(Constants.FEATURE_VERBOSE)) {
       verbose = value;
-    }
-    else if (name.equals(Constants.FEATURE_IMPORT_DOCUMENTS))
-    {
+    } else if (name.equals(Constants.FEATURE_IMPORT_DOCUMENTS)) {
       importDocuments = value;
-    }
-    else if (name.equals(Constants.FEATURE_PARSE_SCHEMA))
-    {
+    } else if (name.equals(Constants.FEATURE_PARSE_SCHEMA)) {
       parseSchema = value;
-    }
-    else
-    {
-      throw new IllegalArgumentException("Feature name '" + name +
-                                         "' not recognized.");
+    } else {
+      throw new IllegalArgumentException("Feature name '" + name + "' not recognized.");
     }
   }
 
   /**
    * Gets the value of the specified feature.
    *
-   * @param name the name of the feature to get the value of.
+   * @param name
+   *          the name of the feature to get the value of.
    * @return the value of the feature.
-   * @throws IllegalArgumentException if the feature name is not recognized.
+   * @throws IllegalArgumentException
+   *           if the feature name is not recognized.
    * @see #setFeature(String, boolean)
    */
-  public boolean getFeature(String name) throws IllegalArgumentException
-  {
-    if (name == null)
-    {
+  public boolean getFeature(String name) throws IllegalArgumentException {
+    if (name == null) {
       throw new IllegalArgumentException("Feature name must not be null.");
     }
 
-    if (name.equals(Constants.FEATURE_VERBOSE))
-    {
+    if (name.equals(Constants.FEATURE_VERBOSE)) {
       return verbose;
-    }
-    else if (name.equals(Constants.FEATURE_IMPORT_DOCUMENTS))
-    {
+    } else if (name.equals(Constants.FEATURE_IMPORT_DOCUMENTS)) {
       return importDocuments;
-    }
-    else
-    {
-      throw new IllegalArgumentException("Feature name '" + name +
-                                         "' not recognized.");
+    } else {
+      throw new IllegalArgumentException("Feature name '" + name + "' not recognized.");
     }
   }
 
   /**
-   * Set the extension registry to be used when reading
-   * WSDL documents into a WSDL definition. If an
-   * extension registry is set, that is the extension
-   * registry that will be set as the extensionRegistry
-   * property of the definitions resulting from invoking
-   * readWSDL(...). Default is null.
+   * Set the extension registry to be used when reading WSDL documents into a WSDL definition. If an extension registry is set, that is the extension registry that will be set as the extensionRegistry property of the definitions resulting from invoking readWSDL(...). Default is null.
    *
-   * @param extReg the extension registry to use for new
-   * definitions
+   * @param extReg
+   *          the extension registry to use for new definitions
    */
-  public void setExtensionRegistry(ExtensionRegistry extReg)
-  {
+  public void setExtensionRegistry(ExtensionRegistry extReg) {
     this.extReg = extReg;
   }
 
   /**
-   * Get the extension registry, if one was set. Default is
-   * null.
+   * Get the extension registry, if one was set. Default is null.
    */
-  public ExtensionRegistry getExtensionRegistry()
-  {
+  public ExtensionRegistry getExtensionRegistry() {
     return extReg;
   }
-  
+
   /**
-   * Get the WSDLFactory object cached in the reader, or use lazy
-   * instantiation if it is not cached yet.
+   * Get the WSDLFactory object cached in the reader, or use lazy instantiation if it is not cached yet.
    */
-  protected WSDLFactory getWSDLFactory() throws WSDLException
-  {
-    if (factory == null)
-    {
-      factory = (factoryImplName != null)
-        ? WSDLFactory.newInstance(factoryImplName)
-        : WSDLFactory.newInstance();
+  protected WSDLFactory getWSDLFactory() throws WSDLException {
+    if (factory == null) {
+      factory = (factoryImplName != null) ? WSDLFactory.newInstance(factoryImplName) : WSDLFactory.newInstance();
     }
     return factory;
   }
 
   /**
-   * Set a different factory implementation to use for
-   * creating definitions when reading WSDL documents.
-   * As some WSDLReader implementations may only be
-   * capable of creating definitions using the same
-   * factory implementation from which the reader was
-   * obtained, this method is optional. Default is null.
+   * Set a different factory implementation to use for creating definitions when reading WSDL documents. As some WSDLReader implementations may only be capable of creating definitions using the same factory implementation from which the reader was obtained, this method is optional. Default is null.
    *
-   * @param factoryImplName the fully-qualified class name of the
-   * class which provides a concrete implementation of the abstract
-   * class WSDLFactory.
-   * @throws UnsupportedOperationException if this method
-   * is invoked on an implementation which does not
-   * support it.
+   * @param factoryImplName
+   *          the fully-qualified class name of the class which provides a concrete implementation of the abstract class WSDLFactory.
+   * @throws UnsupportedOperationException
+   *           if this method is invoked on an implementation which does not support it.
    */
-  public void setFactoryImplName(String factoryImplName)
-    throws UnsupportedOperationException
-  {
-    //check to see if we really need to change the factory name and clear the cache
-    if((this.factoryImplName == null && factoryImplName != null) ||
-       (this.factoryImplName != null && !this.factoryImplName.equals(factoryImplName))) 
-    {
-      //the factory object is cached in the reader so set it
-      //to null if the factory impl name is reset.
+  public void setFactoryImplName(String factoryImplName) throws UnsupportedOperationException {
+    // check to see if we really need to change the factory name and clear the cache
+    if ((this.factoryImplName == null && factoryImplName != null) || (this.factoryImplName != null && !this.factoryImplName.equals(factoryImplName))) {
+      // the factory object is cached in the reader so set it
+      // to null if the factory impl name is reset.
       this.factory = null;
-        
+
       this.factoryImplName = factoryImplName;
-      //if(verbose) System.out.println("WSDLFactory Impl Name set to : "+factoryImplName);
     }
   }
 
   /**
    * Get the factoryImplName, if one was set. Default is null.
    */
-  public String getFactoryImplName()
-  {
+  public String getFactoryImplName() {
     return factoryImplName;
   }
 
-  protected Definition parseDefinitions(String documentBaseURI,
-                                        Element defEl,
-                                        Map importedDefs)
-                                          throws WSDLException
-  {
+  protected Definition parseDefinitions(String documentBaseURI, Element defEl, Map importedDefs) throws WSDLException {
     checkElementName(defEl, Constants.Q_ELEM_DEFINITIONS);
 
-    WSDLFactory factory = getWSDLFactory();
-    Definition def = factory.newDefinition();
+    Definition def = getWSDLFactory().newDefinition();
 
-    if (extReg != null)
-    {
+    if (extReg != null) {
       def.setExtensionRegistry(extReg);
     }
 
     String name = DOMUtils.getAttribute(defEl, Constants.ATTR_NAME);
-    String targetNamespace = DOMUtils.getAttribute(defEl,
-                                             Constants.ATTR_TARGET_NAMESPACE);
+    String targetNamespace = DOMUtils.getAttribute(defEl, Constants.ATTR_TARGET_NAMESPACE);
     NamedNodeMap attrs = defEl.getAttributes();
 
-    if (importedDefs == null)
-    {
+    if (importedDefs == null) {
       importedDefs = new Hashtable();
     }
-    
-    if (documentBaseURI != null)
-    {
+
+    if (documentBaseURI != null) {
       def.setDocumentBaseURI(documentBaseURI);
       importedDefs.put(documentBaseURI, def);
     }
 
-    if (name != null)
-    {
+    if (name != null) {
       def.setQName(new QName(targetNamespace, name));
     }
 
-    if (targetNamespace != null)
-    {
+    if (targetNamespace != null) {
       def.setTargetNamespace(targetNamespace);
     }
 
     int size = attrs.getLength();
 
-    for (int i = 0; i < size; i++)
-    {
-      Attr attr = (Attr)attrs.item(i);
+    for (int i = 0; i < size; i++) {
+      Attr attr = (Attr) attrs.item(i);
       String namespaceURI = attr.getNamespaceURI();
       String localPart = attr.getLocalName();
       String value = attr.getValue();
 
-      if (namespaceURI != null && namespaceURI.equals(Constants.NS_URI_XMLNS))
-      {
-        if (localPart != null && !localPart.equals(Constants.ATTR_XMLNS))
-        {
+      if (namespaceURI != null && namespaceURI.equals(Constants.NS_URI_XMLNS)) {
+        if (localPart != null && !localPart.equals(Constants.ATTR_XMLNS)) {
           def.addNamespace(localPart, value);
-        }
-        else
-        {
+        } else {
           def.addNamespace(null, value);
         }
       }
@@ -305,288 +229,185 @@ public class WSDLReaderImpl implements WSDLReader
 
     Element tempEl = DOMUtils.getFirstChildElement(defEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_IMPORT, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_IMPORT, tempEl)) {
         def.addImport(parseImport(tempEl, def, importedDefs));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         def.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_TYPES, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_TYPES, tempEl)) {
         def.setTypes(parseTypes(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_MESSAGE, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_MESSAGE, tempEl)) {
         def.addMessage(parseMessage(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_PORT_TYPE, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_PORT_TYPE, tempEl)) {
         def.addPortType(parsePortType(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_BINDING, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_BINDING, tempEl)) {
         def.addBinding(parseBinding(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_SERVICE, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_SERVICE, tempEl)) {
         def.addService(parseService(tempEl, def));
-      }
-      else
-      {
-        def.addExtensibilityElement(
-          parseExtensibilityElement(Definition.class, tempEl, def));
+      } else {
+        def.addExtensibilityElement(parseExtensibilityElement(Definition.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(defEl, Definition.class, def, def);
-    
+
     return def;
   }
 
-  protected Import parseImport(Element importEl,
-                               Definition def,
-                               Map importedDefs)
-                                 throws WSDLException
-  {
+  protected Import parseImport(Element importEl, Definition def, Map importedDefs) throws WSDLException {
     Import importDef = def.createImport();
 
-    try
-    {
-      String namespaceURI = DOMUtils.getAttribute(importEl,
-                                                  Constants.ATTR_NAMESPACE);
-      String locationURI = DOMUtils.getAttribute(importEl,
-                                                 Constants.ATTR_LOCATION);
+    try {
+      String namespaceURI = DOMUtils.getAttribute(importEl, Constants.ATTR_NAMESPACE);
+      String locationURI = DOMUtils.getAttribute(importEl, Constants.ATTR_LOCATION);
       String contextURI = null;
 
-      if (namespaceURI != null)
-      {
+      if (namespaceURI != null) {
         importDef.setNamespaceURI(namespaceURI);
       }
 
-      if (locationURI != null)
-      {
+      if (locationURI != null) {
         importDef.setLocationURI(locationURI);
 
-        if (importDocuments)
-        {
-          try
-          {
+        if (importDocuments) {
+          try {
             contextURI = def.getDocumentBaseURI();
             Definition importedDef = null;
             InputStream inputStream = null;
             InputSource inputSource = null;
             URL url = null;
 
-            if (loc != null)
-            {
+            if (loc != null) {
               inputSource = loc.getImportInputSource(contextURI, locationURI);
 
               /*
-                We now have available the latest import URI. This might
-                differ from the locationURI so check the importedDefs for it
-                since it is this that we pass as the documentBaseURI later.
-              */
+               * We now have available the latest import URI. This might differ from the locationURI so check the importedDefs for it since it is this that we pass as the documentBaseURI later.
+               */
               String liu = loc.getLatestImportURI();
 
-              importedDef = (Definition)importedDefs.get(liu);
-              
+              importedDef = (Definition) importedDefs.get(liu);
+
               inputSource.setSystemId(liu);
-            }
-            else
-            {
-              URL contextURL = (contextURI != null)
-                               ? StringUtils.getURL(null, contextURI)
-                               : null;
+            } else {
+              URL contextURL = (contextURI != null) ? StringUtils.getURL(null, contextURI) : null;
 
               url = StringUtils.getURL(contextURL, locationURI);
-              importedDef = (Definition)importedDefs.get(url.toString());
+              importedDef = (Definition) importedDefs.get(url.toString());
 
-              if (importedDef == null)
-              {
+              if (importedDef == null) {
                 inputStream = StringUtils.getContentAsInputStream(url);
 
-                if (inputStream != null)
-                {
+                if (inputStream != null) {
                   inputSource = new InputSource(inputStream);
                   inputSource.setSystemId(url.toString());
                 }
               }
             }
 
-            if (importedDef == null)
-            {
-              if (inputSource == null)
-              {
-                throw new WSDLException(WSDLException.OTHER_ERROR,
-                                        "Unable to locate imported document " +
-                                        "at '" + locationURI + "'" +
-                                        (contextURI == null
-                                         ? "."
-                                         : ", relative to '" + contextURI +
-                                         "'."));
+            if (importedDef == null) {
+              if (inputSource == null) {
+                throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to locate imported document " + "at '" + locationURI + "'" + (contextURI == null ? "." : ", relative to '" + contextURI + "'."));
               }
 
               Document doc = getDocument(inputSource, inputSource.getSystemId());
 
-              if (inputStream != null)
-              {
+              if (inputStream != null) {
                 inputStream.close();
               }
 
               Element documentElement = doc.getDocumentElement();
 
               /*
-                Check if it's a wsdl document.
-                If it's not, don't retrieve and process it.
-                This should later be extended to allow other types of
-                documents to be retrieved and processed, such as schema
-                documents (".xsd"), etc...
-              */
-              if (QNameUtils.matches(Constants.Q_ELEM_DEFINITIONS,
-                                     documentElement))
-              {
-                if (verbose)
-                {
-                  System.out.println("Retrieving document at '" + locationURI +
-                                     "'" +
-                                     (contextURI == null
-                                      ? "."
-                                      : ", relative to '" + contextURI + "'."));
+               * Check if it's a wsdl document. If it's not, don't retrieve and process it. This should later be extended to allow other types of documents to be retrieved and processed, such as schema documents (".xsd"), etc...
+               */
+              if (QNameUtils.matches(Constants.Q_ELEM_DEFINITIONS, documentElement)) {
+                if (verbose) {
+                  System.out.println("Retrieving document at '" + locationURI + "'" + (contextURI == null ? "." : ", relative to '" + contextURI + "'."));
                 }
 
-                String urlString =
-                  (loc != null)
-                  ? loc.getLatestImportURI()
-                  : (url != null)
-                    ? url.toString()
-                    : locationURI;
+                String urlString = (loc != null) ? loc.getLatestImportURI() : (url != null) ? url.toString() : locationURI;
 
-                importedDef = readWSDL(urlString,
-                                       documentElement,
-                                       importedDefs);
-              }
-              else
-              {
+                importedDef = readWSDL(urlString, documentElement, importedDefs);
+              } else {
                 QName docElementQName = QNameUtils.newQName(documentElement);
 
-                if (SchemaConstants.XSD_QNAME_LIST.contains(docElementQName))
-                {
-                  if (verbose)
-                  {
-                    System.out.println("Retrieving schema wsdl:imported from '" + locationURI +
-                                       "'" +
-                                       (contextURI == null
-                                        ? "."
-                                        : ", relative to '" + contextURI + "'."));
+                if (SchemaConstants.XSD_QNAME_LIST.contains(docElementQName)) {
+                  if (verbose) {
+                    System.out.println("Retrieving schema wsdl:imported from '" + locationURI + "'" + (contextURI == null ? "." : ", relative to '" + contextURI + "'."));
                   }
-                    
+
                   WSDLFactory factory = getWSDLFactory();
 
                   importedDef = factory.newDefinition();
 
-                  if (extReg != null)
-                  {
+                  if (extReg != null) {
                     importedDef.setExtensionRegistry(extReg);
                   }
 
-                  String urlString =
-                    (loc != null)
-                    ? loc.getLatestImportURI()
-                    : (url != null)
-                      ? url.toString()
-                      : locationURI;
+                  String urlString = (loc != null) ? loc.getLatestImportURI() : (url != null) ? url.toString() : locationURI;
 
                   importedDef.setDocumentBaseURI(urlString);
 
                   Types types = importedDef.createTypes();
-                  types.addExtensibilityElement(
-                      parseSchema(Types.class, documentElement, importedDef));
+                  types.addExtensibilityElement(parseSchema(Types.class, documentElement, importedDef));
                   importedDef.setTypes(types);
                 }
               }
             }
 
-            if (importedDef != null)
-            {
+            if (importedDef != null) {
               importDef.setDefinition(importedDef);
             }
-          }
-          catch (WSDLException e)
-          {
-           throw e;
-          }
-          catch (RuntimeException e)
-          {
+          } catch (WSDLException e) {
             throw e;
+          } catch (RuntimeException e) {
+            throw e;
+          } catch (Exception e) {
+            throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to resolve imported document at '" + locationURI + (contextURI == null ? "'." : "', relative to '" + contextURI + "'"), e);
           }
-          catch (Exception e)
-          {
-            throw new WSDLException(WSDLException.OTHER_ERROR,
-                                    "Unable to resolve imported document at '" +
-                                    locationURI + 
-                                    (contextURI == null 
-                                    ? "'." : "', relative to '" + contextURI + "'")
-                                    , e);
-          }
-        } //end importDocs
-      } //end locationURI
-      
-    }
-    catch (WSDLException e)
-    {
-      if (e.getLocation() == null)
-      {
+        } // end importDocs
+      } // end locationURI
+
+    } catch (WSDLException e) {
+      if (e.getLocation() == null) {
         e.setLocation(XPathUtils.getXPathExprFromNode(importEl));
-      }
-      else
-      {
-        //If definitions are being parsed recursively for nested imports
-        //the exception location must be built up recursively too so
-        //prepend this element's xpath to exception location.
+      } else {
+        // If definitions are being parsed recursively for nested imports
+        // the exception location must be built up recursively too so
+        // prepend this element's xpath to exception location.
         String loc = XPathUtils.getXPathExprFromNode(importEl) + e.getLocation();
         e.setLocation(loc);
       }
 
-	  throw e; 
-	}
+      throw e;
+    }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = importEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(importEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         importDef.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        importDef.addExtensibilityElement(
-          parseExtensibilityElement(Import.class, tempEl, def));        
+      } else {
+        importDef.addExtensibilityElement(parseExtensibilityElement(Import.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
-     }
+    }
 
     parseExtensibilityAttributes(importEl, Import.class, importDef, def);
-    
-    return importDef; 
-    
+
+    return importDef;
+
   }
 
-  protected Types parseTypes(Element typesEl, Definition def)
-    throws WSDLException
-  {
-    //register any NS decls with the Definition
+  protected Types parseTypes(Element typesEl, Definition def) throws WSDLException {
+    // register any NS decls with the Definition
     NamedNodeMap attrs = typesEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
@@ -594,369 +415,261 @@ public class WSDLReaderImpl implements WSDLReader
     Element tempEl = DOMUtils.getFirstChildElement(typesEl);
     QName tempElType;
 
-    while (tempEl != null)
-    {
+    while (tempEl != null) {
       tempElType = QNameUtils.newQName(tempEl);
-      
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         types.setDocumentationElement(tempEl);
-      }
-      else if ((SchemaConstants.XSD_QNAME_LIST).contains(tempElType))
-      {
-        if (parseSchema)
-        {
-      	  //the element qname indicates it is a schema.
-          types.addExtensibilityElement(
-            parseSchema(Types.class, tempEl, def));
+      } else if ((SchemaConstants.XSD_QNAME_LIST).contains(tempElType)) {
+        if (parseSchema) {
+          // the element qname indicates it is a schema.
+          types.addExtensibilityElement(parseSchema(Types.class, tempEl, def));
+        } else {
+          types.addExtensibilityElement(parseExtensibilityElementAsDefaultExtensiblityElement(Types.class, tempEl, def));
         }
-        else 
-        {
-          types.addExtensibilityElement(parseExtensibilityElementAsDefaultExtensiblityElement(Types.class, tempEl, def));        	
-        }
-      }
-      else
-      {
-        types.addExtensibilityElement(
-          parseExtensibilityElement(Types.class, tempEl, def));
+      } else {
+        types.addExtensibilityElement(parseExtensibilityElement(Types.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(typesEl, Types.class, types, def);
-    
+
     return types;
   }
-  
-  protected ExtensibilityElement parseSchema( Class parentType,
-  	                                          Element el,
-                                              Definition def)
-  	                                   throws WSDLException
-  {
+
+  protected ExtensibilityElement parseSchema(Class parentType, Element el, Definition def) throws WSDLException {
     QName elementType = null;
     ExtensionRegistry extReg = null;
 
-  	try
-  	{
-  	  extReg = def.getExtensionRegistry();
+    try {
+      extReg = def.getExtensionRegistry();
 
-  	  if (extReg == null)
-  	  {
-  	    throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-  	                            "No ExtensionRegistry set for this " +
-  	                            "Definition, so unable to deserialize " +
-  	                            "a '" + elementType + "' element in the " +
-  	                            "context of a '" + parentType.getName() +
-  	                            "'.");
-  	  }
+      if (extReg == null) {
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionRegistry set for this " + "Definition, so unable to deserialize " + "a '" + elementType + "' element in the " + "context of a '" + parentType.getName() + "'.");
+      }
 
-  	  return parseSchema(parentType, el, def, extReg);
-  	}
-  	catch (WSDLException e)
-  	{
-      if (e.getLocation() == null)
-      {
+      return parseSchema(parentType, el, def, extReg);
+    } catch (WSDLException e) {
+      if (e.getLocation() == null) {
         e.setLocation(XPathUtils.getXPathExprFromNode(el));
       }
-       
-  	  throw e;
-  	}
-  }
-  	      
 
-  protected ExtensibilityElement parseSchema( Class parentType,
-                                Element el,
-  	                            Definition def,
-                                ExtensionRegistry extReg)
-                   throws WSDLException
-  {
+      throw e;
+    }
+  }
+
+  protected ExtensibilityElement parseSchema(Class parentType, Element el, Definition def, ExtensionRegistry extReg) throws WSDLException {
     /*
-     * This method returns ExtensibilityElement rather than Schema because we
-     * do not insist that a suitable XSD schema deserializer is registered.
-     * PopulatedExtensionRegistry registers SchemaDeserializer by default, but 
-     * if the user chooses not to register a suitable deserializer then the
-     * UnknownDeserializer will be used, returning an UnknownExtensibilityElement. 
+     * This method returns ExtensibilityElement rather than Schema because we do not insist that a suitable XSD schema deserializer is registered. PopulatedExtensionRegistry registers SchemaDeserializer by default, but if the user chooses not to register a suitable deserializer then the
+     * UnknownDeserializer will be used, returning an UnknownExtensibilityElement.
      */
-     
-  	Schema schema = null;
+
+    Schema schema = null;
     SchemaReference schemaRef = null;
-  	try
-  	{
+    try {
 
       QName elementType = QNameUtils.newQName(el);
-      
- 	  ExtensionDeserializer exDS = 
- 	    extReg.queryDeserializer(parentType, elementType);
- 	  
-      //Now unmarshall the DOM element.
- 	  ExtensibilityElement ee =  
-        exDS.unmarshall(parentType, elementType, el, def, extReg);
-      
- 	  if (ee instanceof Schema)
- 	  {
- 	    schema = (Schema) ee;
- 	  }
- 	  else
- 	  {
- 	    //Unknown extensibility element, so don't do any more schema parsing on it.
- 	    return ee;
- 	  }
 
+      ExtensionDeserializer exDS = extReg.queryDeserializer(parentType, elementType);
 
-      //Keep track of parsed schemas to avoid duplicating Schema objects
- 	  //through duplicate or circular references (eg: A imports B imports A).
- 	  if (schema.getDocumentBaseURI() != null) 
- 	  {
- 	    this.allSchemas.put(schema.getDocumentBaseURI(), schema);
- 	  }
-  	      
-  	  //At this point, any SchemaReference objects held by the schema will not 
-      //yet point to their referenced schemas, so we must now retrieve these 
-      //schemas and set the schema references.
-  	      
-  	  //First, combine the schema references for imports, includes and redefines 
-      //into a single list
-      
-  	  ArrayList allSchemaRefs = new ArrayList();
-  	
-  	  Collection ic = schema.getImports().values();
-  	  Iterator importsIterator = ic.iterator();
-  	  while(importsIterator.hasNext())
-  	  {
-  	    allSchemaRefs.addAll( (Collection) importsIterator.next() );
-  	  }
-  	
-  	  allSchemaRefs.addAll(schema.getIncludes());
-  	  allSchemaRefs.addAll(schema.getRedefines());
-  	      
-  	  //Then, retrieve the schema referred to by each schema reference. If the 
-  	  //schema has been read in previously, use the existing schema object. 
-  	  //Otherwise unmarshall the DOM element into a new schema object.
-  	      
-  	  ListIterator schemaRefIterator = allSchemaRefs.listIterator();
-  	      
-  	  while(schemaRefIterator.hasNext()) 
-  	  {
-  	    try
-  	    {
-  	      schemaRef = (SchemaReference) schemaRefIterator.next();
-  	          
-  	      if (schemaRef.getSchemaLocationURI() == null)
-  	      {
-  	        //cannot get the referenced schema, so ignore this schema reference
-  	        continue;
-  	      }
-  	      
-  	      if (verbose)
-  	      {
-  	        System.out.println("Retrieving schema at '" + 
-  	                           schemaRef.getSchemaLocationURI() +
-  	                          (schema.getDocumentBaseURI() == null
-  	                           ? "'."
-  	                           : "', relative to '" + 
-  	                           schema.getDocumentBaseURI() + "'."));
-  	      }
+      // Now unmarshall the DOM element.
+      ExtensibilityElement ee = exDS.unmarshall(parentType, elementType, el, def, extReg);
 
-  	  	      
-  	      InputStream inputStream = null;
-  	      InputSource inputSource = null;
-  	  	      
-  	      //This is the child schema referred to by the schemaReference
-  	      Schema referencedSchema = null;
-  	  	      
-  	      //This is the child schema's location obtained from the WSDLLocator or the URL
-  	      String location = null;
+      if (ee instanceof Schema) {
+        schema = (Schema) ee;
+      } else {
+        // Unknown extensibility element, so don't do any more schema parsing on it.
+        return ee;
+      }
 
-  	      if (loc != null)
-  	      {
-  	        //Try to get the referenced schema using the wsdl locator
-  	        inputSource = loc.getImportInputSource(
-  	          schema.getDocumentBaseURI(), schemaRef.getSchemaLocationURI());
-  	    
-  	  	    if (inputSource == null)
-  	  	    {
-  	  	      throw new WSDLException(WSDLException.OTHER_ERROR,
-  	                    "Unable to locate with a locator "
-                        + "the schema referenced at '"
-  	  	                + schemaRef.getSchemaLocationURI() 
-  	  	                + "' relative to document base '"
-  	  	                + schema.getDocumentBaseURI() + "'");
-  	  	    }
-  	  	    location = loc.getLatestImportURI();
-  	  	        
-  	  	    //if a schema from this location has been read previously, use it.
-  	  	    referencedSchema = (Schema) this.allSchemas.get(location);
-  	      }
-  	      else
-   	      {
-  	  	    // We don't have a wsdl locator, so try to retrieve the schema by its URL
-  	  	    String contextURI = schema.getDocumentBaseURI();
-  	  	    URL contextURL = (contextURI != null) ? StringUtils.getURL(null, contextURI) : null;
-  	  	    URL url = StringUtils.getURL(contextURL, schemaRef.getSchemaLocationURI());
-  	  	    location = url.toExternalForm();
-    	  	        
-    	    //if a schema from this location has been retrieved previously, use it.
-  	  	    referencedSchema = (Schema) this.allSchemas.get(location);
+      // Keep track of parsed schemas to avoid duplicating Schema objects
+      // through duplicate or circular references (eg: A imports B imports A).
+      if (schema.getDocumentBaseURI() != null) {
+        this.allSchemas.put(schema.getDocumentBaseURI(), schema);
+      }
 
-  	  	    if (referencedSchema == null)
-  	  	    {
-  	  	      // We haven't read this schema in before so do it now
+      // At this point, any SchemaReference objects held by the schema will not
+      // yet point to their referenced schemas, so we must now retrieve these
+      // schemas and set the schema references.
+
+      // First, combine the schema references for imports, includes and redefines
+      // into a single list
+
+      ArrayList allSchemaRefs = new ArrayList();
+
+      Collection ic = schema.getImports().values();
+      Iterator importsIterator = ic.iterator();
+      while (importsIterator.hasNext()) {
+        allSchemaRefs.addAll((Collection) importsIterator.next());
+      }
+
+      allSchemaRefs.addAll(schema.getIncludes());
+      allSchemaRefs.addAll(schema.getRedefines());
+
+      // Then, retrieve the schema referred to by each schema reference. If the
+      // schema has been read in previously, use the existing schema object.
+      // Otherwise unmarshall the DOM element into a new schema object.
+
+      ListIterator schemaRefIterator = allSchemaRefs.listIterator();
+
+      while (schemaRefIterator.hasNext()) {
+        try {
+          schemaRef = (SchemaReference) schemaRefIterator.next();
+
+          if (schemaRef.getSchemaLocationURI() == null) {
+            // cannot get the referenced schema, so ignore this schema reference
+            continue;
+          }
+
+          if (verbose) {
+            System.out.println("Retrieving schema at '" + schemaRef.getSchemaLocationURI() + (schema.getDocumentBaseURI() == null ? "'." : "', relative to '" + schema.getDocumentBaseURI() + "'."));
+          }
+
+          InputStream inputStream = null;
+          InputSource inputSource = null;
+
+          // This is the child schema referred to by the schemaReference
+          Schema referencedSchema = null;
+
+          // This is the child schema's location obtained from the WSDLLocator or the URL
+          String location = null;
+
+          if (loc != null) {
+            // Try to get the referenced schema using the wsdl locator
+            inputSource = loc.getImportInputSource(schema.getDocumentBaseURI(), schemaRef.getSchemaLocationURI());
+
+            if (inputSource == null) {
+              throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to locate with a locator " + "the schema referenced at '" + schemaRef.getSchemaLocationURI() + "' relative to document base '" + schema.getDocumentBaseURI() + "'");
+            }
+            location = loc.getLatestImportURI();
+
+            // if a schema from this location has been read previously, use it.
+            referencedSchema = (Schema) this.allSchemas.get(location);
+          } else {
+            // We don't have a wsdl locator, so try to retrieve the schema by its URL
+            String contextURI = schema.getDocumentBaseURI();
+            URL contextURL = (contextURI != null) ? StringUtils.getURL(null, contextURI) : null;
+            URL url = StringUtils.getURL(contextURL, schemaRef.getSchemaLocationURI());
+            location = url.toExternalForm();
+
+            // if a schema from this location has been retrieved previously, use it.
+            referencedSchema = (Schema) this.allSchemas.get(location);
+
+            if (referencedSchema == null) {
+              // We haven't read this schema in before so do it now
               inputStream = StringUtils.getContentAsInputStream(url);
 
-  	  	      if (inputStream != null)
-  	  	      {
-  	  	        inputSource = new InputSource(inputStream);
-  	  	      }
-            
-              if (inputSource == null)
-              {
-                throw new WSDLException(WSDLException.OTHER_ERROR,
-  	  	                  "Unable to locate with a url "
-  	                      + "the document referenced at '"
-  	                      + schemaRef.getSchemaLocationURI()
-  	                      + "'"
-  	                      + (contextURI == null ? "." : ", relative to '"
-                          + contextURI + "'."));
+              if (inputStream != null) {
+                inputSource = new InputSource(inputStream);
               }
-  	  	    }  
-  	  	
-  	      } //end if loc
-  	  	      
-  	      // If we have not previously read the schema, get its DOM element now.
-  	      if (referencedSchema == null)
-  	      {
-  	        inputSource.setSystemId(location);
-  	  	    Document doc = getDocument(inputSource, location);
 
-  	  	    if (inputStream != null)
-  	  	    {
-  	  	      inputStream.close();
-  	  	    }
+              if (inputSource == null) {
+                throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to locate with a url " + "the document referenced at '" + schemaRef.getSchemaLocationURI() + "'" + (contextURI == null ? "." : ", relative to '" + contextURI + "'."));
+              }
+            }
 
-  	  	    Element documentElement = doc.getDocumentElement();
+          } // end if loc
 
-  	  	    // If it's a schema doc process it, otherwise the schema reference remains null
+          // If we have not previously read the schema, get its DOM element now.
+          if (referencedSchema == null) {
+            inputSource.setSystemId(location);
+            Document doc = getDocument(inputSource, location);
 
-  	  	    QName docElementQName = QNameUtils.newQName(documentElement);
+            if (inputStream != null) {
+              inputStream.close();
+            }
 
-  	  	    if (SchemaConstants.XSD_QNAME_LIST.contains(docElementQName))
-  	  	    {
-  	  	      //We now need to call parseSchema recursively to parse the referenced
-  	  	      //schema. The document base URI of the referenced schema will be set to 
-  	  	      //the document base URI of the current schema plus the schemaLocation in 
-  	  	      //the schemaRef. We cannot explicitly pass in a new document base URI
-  	  	      //to the schema deserializer, so instead we will create a dummy 
-  	  	      //Definition and set its documentBaseURI to the new document base URI. 
-  	  	      //We can leave the other definition fields empty because we know
-  	  	      //that the SchemaDeserializer.unmarshall method uses the definition 
-  	  	      //parameter only to get its documentBaseURI. If the unmarshall method
-  	  	      //implementation changes (ie: its use of definition changes) we may need 
-  	  	      //to rethink this approach.
-  	  	      
+            Element documentElement = doc.getDocumentElement();
+
+            // If it's a schema doc process it, otherwise the schema reference remains null
+
+            QName docElementQName = QNameUtils.newQName(documentElement);
+
+            if (SchemaConstants.XSD_QNAME_LIST.contains(docElementQName)) {
+              // We now need to call parseSchema recursively to parse the referenced
+              // schema. The document base URI of the referenced schema will be set to
+              // the document base URI of the current schema plus the schemaLocation in
+              // the schemaRef. We cannot explicitly pass in a new document base URI
+              // to the schema deserializer, so instead we will create a dummy
+              // Definition and set its documentBaseURI to the new document base URI.
+              // We can leave the other definition fields empty because we know
+              // that the SchemaDeserializer.unmarshall method uses the definition
+              // parameter only to get its documentBaseURI. If the unmarshall method
+              // implementation changes (ie: its use of definition changes) we may need
+              // to rethink this approach.
+
               WSDLFactory factory = getWSDLFactory();
               Definition dummyDef = factory.newDefinition();
-            
+
               dummyDef.setDocumentBaseURI(location);
 
-              //By this point, we know we have a SchemaDeserializer registered
-              //so we can safely cast the ExtensibilityElement to a Schema.
-  	  	      referencedSchema = (Schema) parseSchema( parentType, 
-  	  	                                               documentElement, 
-  	  	                                               dummyDef,
-  	  	                                               extReg);
-  	  	    }
-  	  	
-  	      } //end if referencedSchema
-
-  	      schemaRef.setReferencedSchema(referencedSchema);  	
-  	    }
-  	    catch (WSDLException e)
-  	    {
-  	      throw e;
-  	    }
-            catch (RuntimeException e)
-            {
-              throw e;
+              // By this point, we know we have a SchemaDeserializer registered
+              // so we can safely cast the ExtensibilityElement to a Schema.
+              referencedSchema = (Schema) parseSchema(parentType, documentElement, dummyDef, extReg);
             }
-  	    catch (Exception e)
-  	    {
-              throw new WSDLException(WSDLException.OTHER_ERROR,
-  	                "An error occurred trying to resolve schema referenced at '" 
-  	  	            + schemaRef.getSchemaLocationURI() 
-  	  	            + "'"
-  		            + (schema.getDocumentBaseURI() == null ? "." : ", relative to '"
-  		            + schema.getDocumentBaseURI() + "'."),
-  	  	            e);
-  	    }
-  	    
-  	  } //end while loop
 
-  	  return schema;
+          } // end if referencedSchema
 
-	}
-	catch (WSDLException e)
-	{
-      if (e.getLocation() == null)
-      {
+          schemaRef.setReferencedSchema(referencedSchema);
+        } catch (WSDLException e) {
+          throw e;
+        } catch (RuntimeException e) {
+          throw e;
+        } catch (Exception e) {
+          throw new WSDLException(WSDLException.OTHER_ERROR, "An error occurred trying to resolve schema referenced at '" + schemaRef.getSchemaLocationURI() + "'" + (schema.getDocumentBaseURI() == null ? "." : ", relative to '" + schema.getDocumentBaseURI() + "'."), e);
+        }
+
+      } // end while loop
+
+      return schema;
+
+    } catch (WSDLException e) {
+      if (e.getLocation() == null) {
         e.setLocation(XPathUtils.getXPathExprFromNode(el));
-      }
-      else
-      {
-        //If this method has been called recursively for nested schemas
-        //the exception location must be built up recursively too so
-        //prepend this element's xpath to exception location.
+      } else {
+        // If this method has been called recursively for nested schemas
+        // the exception location must be built up recursively too so
+        // prepend this element's xpath to exception location.
         String loc = XPathUtils.getXPathExprFromNode(el) + e.getLocation();
         e.setLocation(loc);
       }
 
-	  throw e; 
-	}
-  	
+      throw e;
+    }
+
   }
 
-
-  protected Binding parseBinding(Element bindingEl, Definition def)
-    throws WSDLException
-  {
+  protected Binding parseBinding(Element bindingEl, Definition def) throws WSDLException {
     Binding binding = null;
-    
+
     List remainingAttrs = DOMUtils.getAttributes(bindingEl);
     String name = DOMUtils.getAttribute(bindingEl, Constants.ATTR_NAME, remainingAttrs);
-    QName portTypeName = getQualifiedAttributeValue(bindingEl,
-                                                    Constants.ATTR_TYPE,
-                                                    Constants.ELEM_BINDING,
-                                                    def,
-                                                    remainingAttrs);
-        
+    QName portTypeName = getQualifiedAttributeValue(bindingEl, Constants.ATTR_TYPE, Constants.ELEM_BINDING, def, remainingAttrs);
+
     PortType portType = null;
 
-    if (name != null)
-    {
+    if (name != null) {
       QName bindingName = new QName(def.getTargetNamespace(), name);
 
       binding = def.getBinding(bindingName);
 
-      if (binding == null)
-      {
+      if (binding == null) {
         binding = def.createBinding();
         binding.setQName(bindingName);
       }
-    }
-    else
-    {
+    } else {
       binding = def.createBinding();
     }
 
     // Whether it was retrieved or created, the definition has been found.
     binding.setUndefined(false);
 
-    if (portTypeName != null)
-    {
+    if (portTypeName != null) {
       portType = def.getPortType(portTypeName);
 
-      if (portType == null)
-      {
+      if (portType == null) {
         portType = def.createPortType();
         portType.setQName(portTypeName);
         def.addPortType(portType);
@@ -965,135 +678,90 @@ public class WSDLReaderImpl implements WSDLReader
       binding.setPortType(portType);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = bindingEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(bindingEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         binding.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_OPERATION, tempEl))
-      {
-        binding.addBindingOperation(parseBindingOperation(tempEl,
-                                                          portType,
-                                                          def));
-      }
-      else
-      {
-        binding.addExtensibilityElement(parseExtensibilityElement(
-          Binding.class, tempEl, def));
+      } else if (QNameUtils.matches(Constants.Q_ELEM_OPERATION, tempEl)) {
+        binding.addBindingOperation(parseBindingOperation(tempEl, portType, def));
+      } else {
+        binding.addExtensibilityElement(parseExtensibilityElement(Binding.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(bindingEl, Binding.class, binding, def);
-    
+
     return binding;
   }
 
-  protected BindingOperation parseBindingOperation(
-    Element bindingOperationEl,
-    PortType portType,
-    Definition def)
-      throws WSDLException
-  {
+  protected BindingOperation parseBindingOperation(Element bindingOperationEl, PortType portType, Definition def) throws WSDLException {
     BindingOperation bindingOperation = def.createBindingOperation();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(bindingOperationEl);
-    String name = DOMUtils.getAttribute(bindingOperationEl,
-                                        Constants.ATTR_NAME,
-                                        remainingAttrs);
-    
-    if (name != null)
-    {
+    String name = DOMUtils.getAttribute(bindingOperationEl, Constants.ATTR_NAME, remainingAttrs);
+
+    if (name != null) {
       bindingOperation.setName(name);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = bindingOperationEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(bindingOperationEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         bindingOperation.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_INPUT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_INPUT, tempEl)) {
         bindingOperation.setBindingInput(parseBindingInput(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_OUTPUT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_OUTPUT, tempEl)) {
         bindingOperation.setBindingOutput(parseBindingOutput(tempEl, def));
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_FAULT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_FAULT, tempEl)) {
         bindingOperation.addBindingFault(parseBindingFault(tempEl, def));
-      }
-      else
-      {
-        bindingOperation.addExtensibilityElement(
-          parseExtensibilityElement(BindingOperation.class, tempEl, def));
+      } else {
+        bindingOperation.addExtensibilityElement(parseExtensibilityElement(BindingOperation.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
-    if (portType != null)
-    {
+    if (portType != null) {
       BindingInput bindingInput = bindingOperation.getBindingInput();
       BindingOutput bindingOutput = bindingOperation.getBindingOutput();
-      String inputName = (bindingInput != null 
-              ? (bindingInput.getName() != null ? bindingInput.getName() : Constants.NONE)
-              : null);
-      String outputName = (bindingOutput != null 
-              ? (bindingOutput.getName() != null ? bindingOutput.getName() : Constants.NONE) 
-              : null);
+      String inputName = (bindingInput != null ? (bindingInput.getName() != null ? bindingInput.getName() : Constants.NONE) : null);
+      String outputName = (bindingOutput != null ? (bindingOutput.getName() != null ? bindingOutput.getName() : Constants.NONE) : null);
       Operation op = portType.getOperation(name, inputName, outputName);
-      
+
       /*
-       * If the bindingOp input or output message names are null we will search first
-       * for a porttypeOp with corresponding unnamed input or output messages (using  
-       * Constants.NONE for inputName or outputName, as above). 
-       * However, input and output message names need not be used at all if operation 
-       * overloading is not used, so if no match was found we will try again ignoring 
-       * these unnamed messages from the search criteria (i.e. using null instead of 
-       * Constants.NONE for inputName or outputName).
+       * If the bindingOp input or output message names are null we will search first for a porttypeOp with corresponding unnamed input or output messages (using Constants.NONE for inputName or outputName, as above). However, input and output message names need not be used at all if operation
+       * overloading is not used, so if no match was found we will try again ignoring these unnamed messages from the search criteria (i.e. using null instead of Constants.NONE for inputName or outputName).
        */
-      
-      if(op == null)
-      {
-        if(Constants.NONE.equals(inputName) && Constants.NONE.equals(outputName))
-        {
-          //There was no porttype op with unnamed input and output messages,
-          //so ignore input and output name and search on the op name only.
+
+      if (op == null) {
+        if (Constants.NONE.equals(inputName) && Constants.NONE.equals(outputName)) {
+          // There was no porttype op with unnamed input and output messages,
+          // so ignore input and output name and search on the op name only.
           op = portType.getOperation(name, null, null);
-        }
-        else if(Constants.NONE.equals(inputName))
-        {
-          //There was no porttype op with an unnamed input message,
-          //so ignore input name and search on the op name and output name only.
+        } else if (Constants.NONE.equals(inputName)) {
+          // There was no porttype op with an unnamed input message,
+          // so ignore input name and search on the op name and output name only.
           op = portType.getOperation(name, null, outputName);
-        }
-        else if(Constants.NONE.equals(outputName))
-        {
-          //There was no porttype op with an unnamed output message,
-          //so ignore output name and search on the op name and input name only.
+        } else if (Constants.NONE.equals(outputName)) {
+          // There was no porttype op with an unnamed output message,
+          // so ignore output name and search on the op name and input name only.
           op = portType.getOperation(name, inputName, null);
         }
       }
 
-      if (op == null)
-      {
+      if (op == null) {
         Input input = def.createInput();
         Output output = def.createOutput();
 
@@ -1110,84 +778,62 @@ public class WSDLReaderImpl implements WSDLReader
     }
 
     parseExtensibilityAttributes(bindingOperationEl, BindingOperation.class, bindingOperation, def);
-    
+
     return bindingOperation;
   }
 
-  protected BindingInput parseBindingInput(Element bindingInputEl,
-                                           Definition def)
-                                             throws WSDLException
-  {
+  protected BindingInput parseBindingInput(Element bindingInputEl, Definition def) throws WSDLException {
     BindingInput bindingInput = def.createBindingInput();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(bindingInputEl);
-    String name = DOMUtils.getAttribute(bindingInputEl,
-                                        Constants.ATTR_NAME,
-                                        remainingAttrs);
-    
-    if (name != null)
-    {
+    String name = DOMUtils.getAttribute(bindingInputEl, Constants.ATTR_NAME, remainingAttrs);
+
+    if (name != null) {
       bindingInput.setName(name);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = bindingInputEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(bindingInputEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         bindingInput.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        bindingInput.addExtensibilityElement(
-          parseExtensibilityElement(BindingInput.class, tempEl, def));
+      } else {
+        bindingInput.addExtensibilityElement(parseExtensibilityElement(BindingInput.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
-    
+
     parseExtensibilityAttributes(bindingInputEl, BindingInput.class, bindingInput, def);
-    
+
     return bindingInput;
   }
 
-  protected BindingOutput parseBindingOutput(Element bindingOutputEl,
-                                             Definition def)
-                                               throws WSDLException
-  {
+  protected BindingOutput parseBindingOutput(Element bindingOutputEl, Definition def) throws WSDLException {
     BindingOutput bindingOutput = def.createBindingOutput();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(bindingOutputEl);
-    String name = DOMUtils.getAttribute(bindingOutputEl,
-                                        Constants.ATTR_NAME,
-                                        remainingAttrs);
-    
-    if (name != null)
-    {
+    String name = DOMUtils.getAttribute(bindingOutputEl, Constants.ATTR_NAME, remainingAttrs);
+
+    if (name != null) {
       bindingOutput.setName(name);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = bindingOutputEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(bindingOutputEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         bindingOutput.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        bindingOutput.addExtensibilityElement(
-          parseExtensibilityElement(BindingOutput.class, tempEl, def));
+      } else {
+        bindingOutput.addExtensibilityElement(parseExtensibilityElement(BindingOutput.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -1198,151 +844,111 @@ public class WSDLReaderImpl implements WSDLReader
     return bindingOutput;
   }
 
-  protected BindingFault parseBindingFault(Element bindingFaultEl,
-                                           Definition def)
-                                             throws WSDLException
-  {
+  protected BindingFault parseBindingFault(Element bindingFaultEl, Definition def) throws WSDLException {
     BindingFault bindingFault = def.createBindingFault();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(bindingFaultEl);
-    String name = DOMUtils.getAttribute(bindingFaultEl,
-                                        Constants.ATTR_NAME,
-                                        remainingAttrs);
-    
-    if (name != null)
-    {
+    String name = DOMUtils.getAttribute(bindingFaultEl, Constants.ATTR_NAME, remainingAttrs);
+
+    if (name != null) {
       bindingFault.setName(name);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = bindingFaultEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(bindingFaultEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         bindingFault.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        bindingFault.addExtensibilityElement(
-          parseExtensibilityElement(BindingFault.class, tempEl, def));
+      } else {
+        bindingFault.addExtensibilityElement(parseExtensibilityElement(BindingFault.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(bindingFaultEl, BindingFault.class, bindingFault, def);
-    
+
     return bindingFault;
   }
 
-  protected Message parseMessage(Element msgEl, Definition def)
-    throws WSDLException
-  {
+  protected Message parseMessage(Element msgEl, Definition def) throws WSDLException {
     Message msg = null;
-    
+
     List remainingAttrs = DOMUtils.getAttributes(msgEl);
     String name = DOMUtils.getAttribute(msgEl, Constants.ATTR_NAME, remainingAttrs);
-    
-    if (name != null)
-    {
+
+    if (name != null) {
       QName messageName = new QName(def.getTargetNamespace(), name);
 
       msg = def.getMessage(messageName);
 
-      if (msg == null)
-      {
+      if (msg == null) {
         msg = def.createMessage();
         msg.setQName(messageName);
       }
-    }
-    else
-    {
+    } else {
       msg = def.createMessage();
     }
 
     // Whether it was retrieved or created, the definition has been found.
     msg.setUndefined(false);
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = msgEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(msgEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         msg.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_PART, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_PART, tempEl)) {
         msg.addPart(parsePart(tempEl, def));
-      }
-      else  
-      {
-        msg.addExtensibilityElement(
-          parseExtensibilityElement(Message.class, tempEl, def));
+      } else {
+        msg.addExtensibilityElement(parseExtensibilityElement(Message.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(msgEl, Message.class, msg, def);
-    
+
     return msg;
   }
 
-  protected Part parsePart(Element partEl, Definition def)
-    throws WSDLException
-  {
+  protected Part parsePart(Element partEl, Definition def) throws WSDLException {
     Part part = def.createPart();
     String name = DOMUtils.getAttribute(partEl, Constants.ATTR_NAME);
-    QName elementName = getQualifiedAttributeValue(partEl,
-                                                   Constants.ATTR_ELEMENT,
-                                                   Constants.ELEM_MESSAGE,
-                                                   def);
-    QName typeName = getQualifiedAttributeValue(partEl,
-                                                Constants.ATTR_TYPE,
-                                                Constants.ELEM_MESSAGE,
-                                                def);
+    QName elementName = getQualifiedAttributeValue(partEl, Constants.ATTR_ELEMENT, Constants.ELEM_MESSAGE, def);
+    QName typeName = getQualifiedAttributeValue(partEl, Constants.ATTR_TYPE, Constants.ELEM_MESSAGE, def);
 
-    if (name != null)
-    {
+    if (name != null) {
       part.setName(name);
     }
 
-    if (elementName != null)
-    {
+    if (elementName != null) {
       part.setElementName(elementName);
     }
 
-    if (typeName != null)
-    {
+    if (typeName != null) {
       part.setTypeName(typeName);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = partEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(partEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         part.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        part.addExtensibilityElement(
-          parseExtensibilityElement(Part.class, tempEl, def));
+      } else {
+        part.addExtensibilityElement(parseExtensibilityElement(Part.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -1353,38 +959,30 @@ public class WSDLReaderImpl implements WSDLReader
     return part;
   }
 
-  protected void parseExtensibilityAttributes(Element el,
-                                              Class parentType,
-                                              AttributeExtensible attrExt,
-                                              Definition def)
-                                                throws WSDLException
-  {
-    if (attrExt == null) return;
-    
+  protected void parseExtensibilityAttributes(Element el, Class parentType, AttributeExtensible attrExt, Definition def) throws WSDLException {
+    if (attrExt == null)
+      return;
+
     List nativeAttributeNames = attrExt.getNativeAttributeNames();
     NamedNodeMap nodeMap = el.getAttributes();
     int length = nodeMap.getLength();
 
-    for (int i = 0; i < length; i++)
-    {
-      Attr attribute = (Attr)nodeMap.item(i);
+    for (int i = 0; i < length; i++) {
+      Attr attribute = (Attr) nodeMap.item(i);
       String localName = attribute.getLocalName();
       String namespaceURI = attribute.getNamespaceURI();
       String prefix = attribute.getPrefix();
       QName qname = new QName(namespaceURI, localName);
 
-      if (namespaceURI != null && !namespaceURI.equals(Constants.NS_URI_WSDL))
-      {
-        if (!namespaceURI.equals(Constants.NS_URI_XMLNS))
-        {
+      if (namespaceURI != null && !namespaceURI.equals(Constants.NS_URI_WSDL)) {
+        if (!namespaceURI.equals(Constants.NS_URI_XMLNS)) {
           DOMUtils.registerUniquePrefix(prefix, namespaceURI, def);
 
           String strValue = attribute.getValue();
           int attrType = AttributeExtensible.NO_DECLARED_TYPE;
           ExtensionRegistry extReg = def.getExtensionRegistry();
 
-          if (extReg != null)
-          {
+          if (extReg != null) {
             attrType = extReg.queryExtensionAttributeType(parentType, qname);
           }
 
@@ -1392,16 +990,8 @@ public class WSDLReaderImpl implements WSDLReader
 
           attrExt.setExtensionAttribute(qname, val);
         }
-      }
-      else if (!nativeAttributeNames.contains(localName))
-      {
-        WSDLException wsdlExc = new WSDLException(WSDLException.INVALID_WSDL,
-                                                  "Encountered illegal " +
-                                                  "extension attribute '" +
-                                                  qname + "'. Extension " +
-                                                  "attributes must be in " +
-                                                  "a namespace other than " +
-                                                  "WSDL's.");
+      } else if (!nativeAttributeNames.contains(localName)) {
+        WSDLException wsdlExc = new WSDLException(WSDLException.INVALID_WSDL, "Encountered illegal " + "extension attribute '" + qname + "'. Extension " + "attributes must be in " + "a namespace other than " + "WSDL's.");
 
         wsdlExc.setLocation(XPathUtils.getXPathExprFromNode(el));
 
@@ -1410,50 +1000,32 @@ public class WSDLReaderImpl implements WSDLReader
     }
   }
 
-  protected Object parseExtensibilityAttribute(Element el,
-                                               int attrType,
-                                               String attrValue,
-                                               Definition def)
-                                                 throws WSDLException
-  {
-    if (attrType == AttributeExtensible.QNAME_TYPE)
-    {
+  protected Object parseExtensibilityAttribute(Element el, int attrType, String attrValue, Definition def) throws WSDLException {
+    if (attrType == AttributeExtensible.QNAME_TYPE) {
       return DOMUtils.getQName(attrValue, el, def);
-    }
-    else if (attrType == AttributeExtensible.LIST_OF_STRINGS_TYPE)
-    {
+    } else if (attrType == AttributeExtensible.LIST_OF_STRINGS_TYPE) {
       return StringUtils.parseNMTokens(attrValue);
-    }
-    else if (attrType == AttributeExtensible.LIST_OF_QNAMES_TYPE)
-    {
+    } else if (attrType == AttributeExtensible.LIST_OF_QNAMES_TYPE) {
       List oldList = StringUtils.parseNMTokens(attrValue);
       int size = oldList.size();
       List newList = new Vector(size);
 
-      for (int i = 0; i < size; i++)
-      {
-        String str = (String)oldList.get(i);
+      for (int i = 0; i < size; i++) {
+        String str = (String) oldList.get(i);
         QName qValue = DOMUtils.getQName(str, el, def);
 
         newList.add(qValue);
       }
 
       return newList;
-    }
-    else if (attrType == AttributeExtensible.STRING_TYPE)
-    {
+    } else if (attrType == AttributeExtensible.STRING_TYPE) {
       return attrValue;
-    }
-    else
-    {
+    } else {
       QName qValue = null;
 
-      try
-      {
+      try {
         qValue = DOMUtils.getQName(attrValue, el, def);
-      }
-      catch (WSDLException e)
-      {
+      } catch (WSDLException e) {
         qValue = new QName(attrValue);
       }
 
@@ -1461,57 +1033,43 @@ public class WSDLReaderImpl implements WSDLReader
     }
   }
 
-  protected PortType parsePortType(Element portTypeEl, Definition def)
-    throws WSDLException
-  {
+  protected PortType parsePortType(Element portTypeEl, Definition def) throws WSDLException {
     PortType portType = null;
     String name = DOMUtils.getAttribute(portTypeEl, Constants.ATTR_NAME);
 
-    if (name != null)
-    {
+    if (name != null) {
       QName portTypeName = new QName(def.getTargetNamespace(), name);
 
       portType = def.getPortType(portTypeName);
 
-      if (portType == null)
-      {
+      if (portType == null) {
         portType = def.createPortType();
         portType.setQName(portTypeName);
       }
-    }
-    else
-    {
+    } else {
       portType = def.createPortType();
     }
 
     // Whether it was retrieved or created, the definition has been found.
     portType.setUndefined(false);
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = portTypeEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(portTypeEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         portType.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_OPERATION, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_OPERATION, tempEl)) {
         Operation op = parseOperation(tempEl, portType, def);
 
-        if (op != null)
-        {
+        if (op != null) {
           portType.addOperation(op);
         }
-      }
-      else
-      {
-        portType.addExtensibilityElement(
-          parseExtensibilityElement(PortType.class, tempEl, def));
+      } else {
+        portType.addExtensibilityElement(parseExtensibilityElement(PortType.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -1522,20 +1080,14 @@ public class WSDLReaderImpl implements WSDLReader
     return portType;
   }
 
-  protected Operation parseOperation(Element opEl,
-                                     PortType portType,
-                                     Definition def)
-                                       throws WSDLException
-  {
+  protected Operation parseOperation(Element opEl, PortType portType, Definition def) throws WSDLException {
     Operation op = null;
-    
+
     List remainingAttrs = DOMUtils.getAttributes(opEl);
     String name = DOMUtils.getAttribute(opEl, Constants.ATTR_NAME, remainingAttrs);
-    String parameterOrderStr = DOMUtils.getAttribute(opEl,
-                                                     Constants.ATTR_PARAMETER_ORDER,
-                                                     remainingAttrs);
-        
-    //register any NS decls with the Definition
+    String parameterOrderStr = DOMUtils.getAttribute(opEl, Constants.ATTR_PARAMETER_ORDER, remainingAttrs);
+
+    // register any NS decls with the Definition
     NamedNodeMap attrs = opEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
@@ -1548,92 +1100,64 @@ public class WSDLReaderImpl implements WSDLReader
     List extElements = new Vector();
     boolean retrieved = true;
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         docEl = tempEl;
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_INPUT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_INPUT, tempEl)) {
         input = parseInput(tempEl, def);
         messageOrder.add(Constants.ELEM_INPUT);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_OUTPUT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_OUTPUT, tempEl)) {
         output = parseOutput(tempEl, def);
         messageOrder.add(Constants.ELEM_OUTPUT);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_FAULT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_FAULT, tempEl)) {
         faults.add(parseFault(tempEl, def));
-      }
-      else 
-      {
-        extElements.add(
-            parseExtensibilityElement(Operation.class, tempEl, def));
+      } else {
+        extElements.add(parseExtensibilityElement(Operation.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
-    if (name != null)
-    {
-      String inputName = (input != null 
-              ? (input.getName() != null ? input.getName() : Constants.NONE) 
-              : null);
-      String outputName = (output != null 
-              ? (output.getName() != null ? output.getName() : Constants.NONE) 
-              : null);
+    if (name != null) {
+      String inputName = (input != null ? (input.getName() != null ? input.getName() : Constants.NONE) : null);
+      String outputName = (output != null ? (output.getName() != null ? output.getName() : Constants.NONE) : null);
 
       op = portType.getOperation(name, inputName, outputName);
 
-      if (op != null && !op.isUndefined())
-      {
+      if (op != null && !op.isUndefined()) {
         op = null;
       }
 
-      if (op != null)
-      {
-        if (inputName == null)
-        {
+      if (op != null) {
+        if (inputName == null) {
           Input tempIn = op.getInput();
 
-          if (tempIn != null)
-          {
-            if (tempIn.getName() != null)
-            {
+          if (tempIn != null) {
+            if (tempIn.getName() != null) {
               op = null;
             }
           }
         }
       }
 
-      if (op != null)
-      {
-        if (outputName == null)
-        {
+      if (op != null) {
+        if (outputName == null) {
           Output tempOut = op.getOutput();
 
-          if (tempOut != null)
-          {
-            if (tempOut.getName() != null)
-            {
+          if (tempOut != null) {
+            if (tempOut.getName() != null) {
               op = null;
             }
           }
         }
       }
 
-      if (op == null)
-      {
+      if (op == null) {
         op = def.createOperation();
         op.setName(name);
         retrieved = false;
       }
-    }
-    else
-    {
+    } else {
       op = def.createOperation();
       retrieved = false;
     }
@@ -1641,148 +1165,111 @@ public class WSDLReaderImpl implements WSDLReader
     // Whether it was retrieved or created, the definition has been found.
     op.setUndefined(false);
 
-    if (parameterOrderStr != null)
-    {
+    if (parameterOrderStr != null) {
       op.setParameterOrdering(StringUtils.parseNMTokens(parameterOrderStr));
     }
 
-    if (docEl != null)
-    {
+    if (docEl != null) {
       op.setDocumentationElement(docEl);
     }
 
-    if (input != null)
-    {
+    if (input != null) {
       op.setInput(input);
     }
 
-    if (output != null)
-    {
+    if (output != null) {
       op.setOutput(output);
     }
 
-    if (faults.size() > 0)
-    {
+    if (faults.size() > 0) {
       Iterator faultIterator = faults.iterator();
 
-      while (faultIterator.hasNext())
-      {
-        op.addFault((Fault)faultIterator.next());
+      while (faultIterator.hasNext()) {
+        op.addFault((Fault) faultIterator.next());
       }
     }
 
-    if (extElements.size() > 0)
-    {
+    if (extElements.size() > 0) {
       Iterator eeIterator = extElements.iterator();
-      
-      while (eeIterator.hasNext())
-      {
-        op.addExtensibilityElement(
-            (ExtensibilityElement) eeIterator.next() );
+
+      while (eeIterator.hasNext()) {
+        op.addExtensibilityElement((ExtensibilityElement) eeIterator.next());
       }
     }
-    
+
     OperationType style = null;
 
-    if (messageOrder.equals(STYLE_ONE_WAY))
-    {
+    if (messageOrder.equals(STYLE_ONE_WAY)) {
       style = OperationType.ONE_WAY;
-    }
-    else if (messageOrder.equals(STYLE_REQUEST_RESPONSE))
-    {
+    } else if (messageOrder.equals(STYLE_REQUEST_RESPONSE)) {
       style = OperationType.REQUEST_RESPONSE;
-    }
-    else if (messageOrder.equals(STYLE_SOLICIT_RESPONSE))
-    {
+    } else if (messageOrder.equals(STYLE_SOLICIT_RESPONSE)) {
       style = OperationType.SOLICIT_RESPONSE;
-    }
-    else if (messageOrder.equals(STYLE_NOTIFICATION))
-    {
+    } else if (messageOrder.equals(STYLE_NOTIFICATION)) {
       style = OperationType.NOTIFICATION;
     }
 
-    if (style != null)
-    {
+    if (style != null) {
       op.setStyle(style);
     }
 
     parseExtensibilityAttributes(opEl, Operation.class, op, def);
-    
-    if (retrieved)
-    {
+
+    if (retrieved) {
       op = null;
     }
 
     return op;
   }
 
-  protected Service parseService(Element serviceEl, Definition def)
-    throws WSDLException
-  {
+  protected Service parseService(Element serviceEl, Definition def) throws WSDLException {
     Service service = def.createService();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(serviceEl);
     String name = DOMUtils.getAttribute(serviceEl, Constants.ATTR_NAME, remainingAttrs);
-    
-    if (name != null)
-    {
+
+    if (name != null) {
       service.setQName(new QName(def.getTargetNamespace(), name));
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = serviceEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(serviceEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         service.setDocumentationElement(tempEl);
-      }
-      else if (QNameUtils.matches(Constants.Q_ELEM_PORT, tempEl))
-      {
+      } else if (QNameUtils.matches(Constants.Q_ELEM_PORT, tempEl)) {
         service.addPort(parsePort(tempEl, def));
-      }
-      else
-      {
-        service.addExtensibilityElement(
-          parseExtensibilityElement(Service.class, tempEl, def));
+      } else {
+        service.addExtensibilityElement(parseExtensibilityElement(Service.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(serviceEl, Service.class, service, def);
-    
+
     return service;
   }
 
-  protected Port parsePort(Element portEl, Definition def)
-    throws WSDLException
-  {
+  protected Port parsePort(Element portEl, Definition def) throws WSDLException {
     Port port = def.createPort();
-    
+
     List remainingAttrs = DOMUtils.getAttributes(portEl);
     String name = DOMUtils.getAttribute(portEl, Constants.ATTR_NAME, remainingAttrs);
-    QName bindingStr = getQualifiedAttributeValue(portEl,
-                                                  Constants.ATTR_BINDING,
-                                                  Constants.ELEM_PORT,
-                                                  def,
-                                                  remainingAttrs);
-    
-    if (name != null)
-    {
+    QName bindingStr = getQualifiedAttributeValue(portEl, Constants.ATTR_BINDING, Constants.ELEM_PORT, def, remainingAttrs);
+
+    if (name != null) {
       port.setName(name);
     }
 
-    if (bindingStr != null)
-    {
+    if (bindingStr != null) {
       Binding binding = def.getBinding(bindingStr);
 
-      if (binding == null)
-      {
+      if (binding == null) {
         binding = def.createBinding();
         binding.setQName(bindingStr);
         def.addBinding(binding);
@@ -1791,79 +1278,50 @@ public class WSDLReaderImpl implements WSDLReader
       port.setBinding(binding);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = portEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(portEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         port.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        port.addExtensibilityElement(parseExtensibilityElement(Port.class,
-                                                               tempEl,
-                                                               def));
+      } else {
+        port.addExtensibilityElement(parseExtensibilityElement(Port.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
     }
 
     parseExtensibilityAttributes(portEl, Port.class, port, def);
-    
+
     return port;
   }
 
-  protected ExtensibilityElement parseExtensibilityElement(
-    Class parentType,
-    Element el,
-    Definition def)
-      throws WSDLException
-  {
+  protected ExtensibilityElement parseExtensibilityElement(Class parentType, Element el, Definition def) throws WSDLException {
     QName elementType = QNameUtils.newQName(el);
-    
+
     String namespaceURI = el.getNamespaceURI();
 
-    try
-    {
-      if (namespaceURI == null || namespaceURI.equals(Constants.NS_URI_WSDL))
-      {
-        throw new WSDLException(WSDLException.INVALID_WSDL,
-                  "Encountered illegal extension element '" +
-                  elementType + 
-                  "' in the context of a '" +
-                  parentType.getName() +
-                  "'. Extension elements must be in " +
-                  "a namespace other than WSDL's.");
+    try {
+      if (namespaceURI == null || namespaceURI.equals(Constants.NS_URI_WSDL)) {
+        throw new WSDLException(WSDLException.INVALID_WSDL, "Encountered illegal extension element '" + elementType + "' in the context of a '" + parentType.getName() + "'. Extension elements must be in " + "a namespace other than WSDL's.");
       }
-      
+
       ExtensionRegistry extReg = def.getExtensionRegistry();
 
-      if (extReg == null)
-      {
-        throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                "No ExtensionRegistry set for this " +
-                                "Definition, so unable to deserialize " +
-                                "a '" + elementType + "' element in the " +
-                                "context of a '" + parentType.getName() +
-                                "'.");
+      if (extReg == null) {
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionRegistry set for this " + "Definition, so unable to deserialize " + "a '" + elementType + "' element in the " + "context of a '" + parentType.getName() + "'.");
       }
 
-      ExtensionDeserializer extDS = extReg.queryDeserializer(parentType,
-                                                             elementType);
+      ExtensionDeserializer extDS = extReg.queryDeserializer(parentType, elementType);
       NamedNodeMap attrs = el.getAttributes();
       registerNSDeclarations(attrs, def);
-      
+
       return extDS.unmarshall(parentType, elementType, el, def, extReg);
-    }
-    catch (WSDLException e)
-    {
-      if (e.getLocation() == null)
-      {
+    } catch (WSDLException e) {
+      if (e.getLocation() == null) {
         e.setLocation(XPathUtils.getXPathExprFromNode(el));
       }
 
@@ -1872,81 +1330,58 @@ public class WSDLReaderImpl implements WSDLReader
   }
 
   /**
-   * Parse the element using the ExtensionRegistry default deserializer instead using the one
-   * registered. The default deserializer will create an UnknownExtensibilityElement from the element. 
+   * Parse the element using the ExtensionRegistry default deserializer instead using the one registered. The default deserializer will create an UnknownExtensibilityElement from the element.
+   * 
    * @param parentType
    * @param el
    * @param def
-   * @return An instance of the default ExtensibilityElement as registered with the ExtensionRegistry 
+   * @return An instance of the default ExtensibilityElement as registered with the ExtensionRegistry
    * @throws WSDLException
    */
-  protected ExtensibilityElement parseExtensibilityElementAsDefaultExtensiblityElement(
-      Class parentType, Element el, Definition def) throws WSDLException
-  {
+  protected ExtensibilityElement parseExtensibilityElementAsDefaultExtensiblityElement(Class parentType, Element el, Definition def) throws WSDLException {
     QName elementType = QNameUtils.newQName(el);
 
     String namespaceURI = el.getNamespaceURI();
 
-    try
-    {
-      if (namespaceURI == null || namespaceURI.equals(Constants.NS_URI_WSDL))
-      {
-        throw new WSDLException(WSDLException.INVALID_WSDL,
-            "Encountered illegal extension element '" + elementType
-                + "' in the context of a '" + parentType.getName()
-                + "'. Extension elements must be in "
-                + "a namespace other than WSDL's.");
+    try {
+      if (namespaceURI == null || namespaceURI.equals(Constants.NS_URI_WSDL)) {
+        throw new WSDLException(WSDLException.INVALID_WSDL, "Encountered illegal extension element '" + elementType + "' in the context of a '" + parentType.getName() + "'. Extension elements must be in " + "a namespace other than WSDL's.");
       }
 
       ExtensionRegistry extReg = def.getExtensionRegistry();
 
-      if (extReg == null)
-      {
-        throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-            "No ExtensionRegistry set for this "
-                + "Definition, so unable to deserialize " + "a '" + elementType
-                + "' element in the " + "context of a '" + parentType.getName()
-                + "'.");
+      if (extReg == null) {
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionRegistry set for this " + "Definition, so unable to deserialize " + "a '" + elementType + "' element in the " + "context of a '" + parentType.getName() + "'.");
       }
 
       ExtensionDeserializer extDS = extReg.getDefaultDeserializer();
-      
+
       NamedNodeMap attrs = el.getAttributes();
       registerNSDeclarations(attrs, def);
-      
+
       return extDS.unmarshall(parentType, elementType, el, def, extReg);
-    } catch (WSDLException e)
-    {
-      if (e.getLocation() == null)
-      {
+    } catch (WSDLException e) {
+      if (e.getLocation() == null) {
         e.setLocation(XPathUtils.getXPathExprFromNode(el));
       }
 
       throw e;
     }
   }
-  
-  protected Input parseInput(Element inputEl, Definition def)
-    throws WSDLException
-  {
+
+  protected Input parseInput(Element inputEl, Definition def) throws WSDLException {
     Input input = def.createInput();
     String name = DOMUtils.getAttribute(inputEl, Constants.ATTR_NAME);
-    QName messageName = getQualifiedAttributeValue(inputEl,
-                                                   Constants.ATTR_MESSAGE,
-                                                   Constants.ELEM_INPUT,
-                                                   def);
+    QName messageName = getQualifiedAttributeValue(inputEl, Constants.ATTR_MESSAGE, Constants.ELEM_INPUT, def);
 
-    if (name != null)
-    {
+    if (name != null) {
       input.setName(name);
     }
 
-    if (messageName != null)
-    {
+    if (messageName != null) {
       Message message = def.getMessage(messageName);
 
-      if (message == null)
-      {
+      if (message == null) {
         message = def.createMessage();
         message.setQName(messageName);
         def.addMessage(message);
@@ -1955,22 +1390,17 @@ public class WSDLReaderImpl implements WSDLReader
       input.setMessage(message);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = inputEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(inputEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         input.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        input.addExtensibilityElement(
-          parseExtensibilityElement(Input.class, tempEl, def));
+      } else {
+        input.addExtensibilityElement(parseExtensibilityElement(Input.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -1981,27 +1411,19 @@ public class WSDLReaderImpl implements WSDLReader
     return input;
   }
 
-  protected Output parseOutput(Element outputEl, Definition def)
-    throws WSDLException
-  {
+  protected Output parseOutput(Element outputEl, Definition def) throws WSDLException {
     Output output = def.createOutput();
     String name = DOMUtils.getAttribute(outputEl, Constants.ATTR_NAME);
-    QName messageName = getQualifiedAttributeValue(outputEl,
-                                                   Constants.ATTR_MESSAGE,
-                                                   Constants.ELEM_OUTPUT,
-                                                   def);
+    QName messageName = getQualifiedAttributeValue(outputEl, Constants.ATTR_MESSAGE, Constants.ELEM_OUTPUT, def);
 
-    if (name != null)
-    {
+    if (name != null) {
       output.setName(name);
     }
 
-    if (messageName != null)
-    {
+    if (messageName != null) {
       Message message = def.getMessage(messageName);
 
-      if (message == null)
-      {
+      if (message == null) {
         message = def.createMessage();
         message.setQName(messageName);
         def.addMessage(message);
@@ -2010,22 +1432,17 @@ public class WSDLReaderImpl implements WSDLReader
       output.setMessage(message);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = outputEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(outputEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         output.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        output.addExtensibilityElement(
-          parseExtensibilityElement(Output.class, tempEl, def));
+      } else {
+        output.addExtensibilityElement(parseExtensibilityElement(Output.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -2036,27 +1453,19 @@ public class WSDLReaderImpl implements WSDLReader
     return output;
   }
 
-  protected Fault parseFault(Element faultEl, Definition def)
-    throws WSDLException
-  {
+  protected Fault parseFault(Element faultEl, Definition def) throws WSDLException {
     Fault fault = def.createFault();
     String name = DOMUtils.getAttribute(faultEl, Constants.ATTR_NAME);
-    QName messageName = getQualifiedAttributeValue(faultEl,
-                                                   Constants.ATTR_MESSAGE,
-                                                   Constants.ELEM_FAULT,
-                                                   def);
+    QName messageName = getQualifiedAttributeValue(faultEl, Constants.ATTR_MESSAGE, Constants.ELEM_FAULT, def);
 
-    if (name != null)
-    {
+    if (name != null) {
       fault.setName(name);
     }
 
-    if (messageName != null)
-    {
+    if (messageName != null) {
       Message message = def.getMessage(messageName);
 
-      if (message == null)
-      {
+      if (message == null) {
         message = def.createMessage();
         message.setQName(messageName);
         def.addMessage(message);
@@ -2065,22 +1474,17 @@ public class WSDLReaderImpl implements WSDLReader
       fault.setMessage(message);
     }
 
-    //register any NS decls with the Definition
+    // register any NS decls with the Definition
     NamedNodeMap attrs = faultEl.getAttributes();
     registerNSDeclarations(attrs, def);
 
     Element tempEl = DOMUtils.getFirstChildElement(faultEl);
 
-    while (tempEl != null)
-    {
-      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl))
-      {
+    while (tempEl != null) {
+      if (QNameUtils.matches(Constants.Q_ELEM_DOCUMENTATION, tempEl)) {
         fault.setDocumentationElement(tempEl);
-      }
-      else
-      {
-        fault.addExtensibilityElement(
-            parseExtensibilityElement(Fault.class, tempEl, def));
+      } else {
+        fault.addExtensibilityElement(parseExtensibilityElement(Fault.class, tempEl, def));
       }
 
       tempEl = DOMUtils.getNextSiblingElement(tempEl);
@@ -2092,81 +1496,42 @@ public class WSDLReaderImpl implements WSDLReader
   }
 
   /**
-   * This method should be used for elements that support extension
-   * attributes because it does not track unexpected remaining attributes.
+   * This method should be used for elements that support extension attributes because it does not track unexpected remaining attributes.
    */
-  private static QName getQualifiedAttributeValue(Element el,
-                                                  String attrName,
-                                                  String elDesc,
-                                                  Definition def)
-                                                    throws WSDLException
-  {
-    try
-    {
-      return DOMUtils.getQualifiedAttributeValue(el,
-                                                 attrName,
-                                                 elDesc,
-                                                 false,
-                                                 def);
-    }
-    catch (WSDLException e)
-    {
-      if (e.getFaultCode().equals(WSDLException.NO_PREFIX_SPECIFIED))
-      {
+  private static QName getQualifiedAttributeValue(Element el, String attrName, String elDesc, Definition def) throws WSDLException {
+    try {
+      return DOMUtils.getQualifiedAttributeValue(el, attrName, elDesc, false, def);
+    } catch (WSDLException e) {
+      if (e.getFaultCode().equals(WSDLException.NO_PREFIX_SPECIFIED)) {
         String attrValue = DOMUtils.getAttribute(el, attrName);
 
         return new QName(attrValue);
-      }
-      else
-      {
+      } else {
         throw e;
       }
     }
   }
-  
+
   /**
-   * This method should be used for elements that do not support extension
-   * attributes because it tracks unexpected remaining attributes.
+   * This method should be used for elements that do not support extension attributes because it tracks unexpected remaining attributes.
    */
-  private static QName getQualifiedAttributeValue(Element el,
-                                                  String attrName,
-                                                  String elDesc,
-                                                  Definition def,
-                                                  List remainingAttrs)
-                                                    throws WSDLException
-  {
-    try
-    {
-      return DOMUtils.getQualifiedAttributeValue(el,
-                                                 attrName,
-                                                 elDesc,
-                                                 false,
-                                                 def,
-                                                 remainingAttrs);
-    }
-    catch (WSDLException e)
-    {
-      if (e.getFaultCode().equals(WSDLException.NO_PREFIX_SPECIFIED))
-      {
+  private static QName getQualifiedAttributeValue(Element el, String attrName, String elDesc, Definition def, List remainingAttrs) throws WSDLException {
+    try {
+      return DOMUtils.getQualifiedAttributeValue(el, attrName, elDesc, false, def, remainingAttrs);
+    } catch (WSDLException e) {
+      if (e.getFaultCode().equals(WSDLException.NO_PREFIX_SPECIFIED)) {
         String attrValue = DOMUtils.getAttribute(el, attrName, remainingAttrs);
 
         return new QName(attrValue);
-      }
-      else
-      {
+      } else {
         throw e;
       }
     }
   }
 
-  private static void checkElementName(Element el, QName qname)
-    throws WSDLException
-  {
-    if (!QNameUtils.matches(qname, el))
-    {
-      WSDLException wsdlExc = new WSDLException(WSDLException.INVALID_WSDL,
-                                                "Expected element '" +
-                                                qname + "'.");
+  private static void checkElementName(Element el, QName qname) throws WSDLException {
+    if (!QNameUtils.matches(qname, el)) {
+      WSDLException wsdlExc = new WSDLException(WSDLException.INVALID_WSDL, "Expected element '" + qname + "'.");
 
       wsdlExc.setLocation(XPathUtils.getXPathExprFromNode(el));
 
@@ -2174,98 +1539,70 @@ public class WSDLReaderImpl implements WSDLReader
     }
   }
 
-  private static Document getDocument(InputSource inputSource,
-                                      String desc) throws WSDLException
-  {
+  private static Document getDocument(InputSource inputSource, String desc) throws WSDLException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
     factory.setNamespaceAware(true);
     factory.setValidating(false);
 
-    try
-    {
+    try {
       DocumentBuilder builder = factory.newDocumentBuilder();
       Document doc = builder.parse(inputSource);
 
       return doc;
-    }
-    catch (RuntimeException e)
-    {
+    } catch (RuntimeException e) {
       throw e;
-    }
-    catch (Exception e)
-    {
-      throw new WSDLException(WSDLException.PARSER_ERROR,
-                                "Problem parsing '" + desc + "'.",
-                                e);
+    } catch (Exception e) {
+      throw new WSDLException(WSDLException.PARSER_ERROR, "Problem parsing '" + desc + "'.", e);
     }
   }
 
-  private static void registerNSDeclarations(NamedNodeMap attrs, Definition def)
-  {
-      int size = attrs.getLength();
+  private static void registerNSDeclarations(NamedNodeMap attrs, Definition def) {
+    int size = attrs.getLength();
 
-      for (int i = 0; i < size; i++)
-      {
-        Attr attr = (Attr)attrs.item(i);
-        String namespaceURI = attr.getNamespaceURI();
-        String localPart = attr.getLocalName();
-        String value = attr.getValue();
+    for (int i = 0; i < size; i++) {
+      Attr attr = (Attr) attrs.item(i);
+      String namespaceURI = attr.getNamespaceURI();
+      String localPart = attr.getLocalName();
+      String value = attr.getValue();
 
-        if (namespaceURI != null && namespaceURI.equals(Constants.NS_URI_XMLNS))
-        {
-          if (localPart != null && !localPart.equals(Constants.ATTR_XMLNS))
-          {
-            DOMUtils.registerUniquePrefix(localPart, value, def);
-          }
-          else
-          {
-            DOMUtils.registerUniquePrefix(null, value, def);
-          }
+      if (namespaceURI != null && namespaceURI.equals(Constants.NS_URI_XMLNS)) {
+        if (localPart != null && !localPart.equals(Constants.ATTR_XMLNS)) {
+          DOMUtils.registerUniquePrefix(localPart, value, def);
+        } else {
+          DOMUtils.registerUniquePrefix(null, value, def);
         }
       }
+    }
   }
-  
+
   /**
-   * Read the WSDL document accessible via the specified
-   * URI into a WSDL definition.
+   * Read the WSDL document accessible via the specified URI into a WSDL definition.
    *
-   * @param wsdlURI a URI (can be a filename or URL) pointing to a
-   * WSDL XML definition.
+   * @param wsdlURI
+   *          a URI (can be a filename or URL) pointing to a WSDL XML definition.
    * @return the definition.
    */
-  public Definition readWSDL(String wsdlURI) throws WSDLException
-  {
+  public Definition readWSDL(String wsdlURI) throws WSDLException {
     return readWSDL(null, wsdlURI);
   }
 
   /**
-   * Read the WSDL document accessible via the specified
-   * URI into a WSDL definition.
+   * Read the WSDL document accessible via the specified URI into a WSDL definition.
    *
-   * @param contextURI the context in which to resolve the
-   * wsdlURI, if the wsdlURI is relative. Can be null, in which
-   * case it will be ignored.
-   * @param wsdlURI a URI (can be a filename or URL) pointing to a
-   * WSDL XML definition.
+   * @param contextURI
+   *          the context in which to resolve the wsdlURI, if the wsdlURI is relative. Can be null, in which case it will be ignored.
+   * @param wsdlURI
+   *          a URI (can be a filename or URL) pointing to a WSDL XML definition.
    * @return the definition.
    */
-  public Definition readWSDL(String contextURI, String wsdlURI)
-    throws WSDLException
-  {
-    try
-    {
-      if (verbose)
-      {
-        System.out.println("Retrieving document at '" + wsdlURI + "'" +
-                           (contextURI == null
-                            ? "."
-                            : ", relative to '" + contextURI + "'."));
+  public Definition readWSDL(String contextURI, String wsdlURI) throws WSDLException {
+    try {
+      if (verbose) {
+        System.out.println("Retrieving document at '" + wsdlURI + "'" + (contextURI == null ? "." : ", relative to '" + contextURI + "'."));
       }
 
-      URL contextURL = (contextURI != null)
-                       ? StringUtils.getURL(null, contextURI)
-                       : null;
+      URL contextURL = (contextURI != null) ? StringUtils.getURL(null, contextURI) : null;
       URL url = StringUtils.getURL(contextURL, wsdlURI);
       InputStream inputStream = StringUtils.getContentAsInputStream(url);
       InputSource inputSource = new InputSource(inputStream);
@@ -2274,155 +1611,103 @@ public class WSDLReaderImpl implements WSDLReader
 
       inputStream.close();
 
-      Definition def = readWSDL(url.toString(), doc);
-
-      return def;
-    }
-    catch (WSDLException e)
-    {
+      return readWSDL(url.toString(), doc);
+    } catch (WSDLException | RuntimeException e) {
       throw e;
-    }
-    catch (RuntimeException e)
-    {
-      throw e;
-    }
-    catch (Exception e)
-    {
-      throw new WSDLException(WSDLException.OTHER_ERROR,
-                              "Unable to resolve imported document at '" +
-                              wsdlURI +
-                              (contextURI == null
-                              ? "'."
-                              : "', relative to '" + contextURI + "'.")
-                              , e);
+    } catch (Exception e) {
+      throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to resolve imported document at '" + wsdlURI + (contextURI == null ? "'." : "', relative to '" + contextURI + "'."), e);
     }
   }
 
   /**
-   * Read the specified &lt;wsdl:definitions&gt; element into a WSDL
-   * definition.
+   * Read the specified &lt;wsdl:definitions&gt; element into a WSDL definition.
    *
-   * @param documentBaseURI the document base URI of the WSDL definition
-   * described by the element. Will be set as the documentBaseURI
-   * of the returned Definition. Can be null, in which case it
-   * will be ignored.
-   * @param definitionsElement the &lt;wsdl:definitions&gt; element
+   * @param documentBaseURI
+   *          the document base URI of the WSDL definition described by the element. Will be set as the documentBaseURI of the returned Definition. Can be null, in which case it will be ignored.
+   * @param definitionsElement
+   *          the &lt;wsdl:definitions&gt; element
    * @return the definition described by the element.
    */
-  public Definition readWSDL(String documentBaseURI,
-                             Element definitionsElement)
-                               throws WSDLException
-  {
+  public Definition readWSDL(String documentBaseURI, Element definitionsElement) throws WSDLException {
     return readWSDL(documentBaseURI, definitionsElement, null);
   }
 
   /**
-   * Read the specified &lt;wsdl:definitions&gt; element into a WSDL
-   * definition. The WSDLLocator is used to provide the document
-   * base URIs. The InputSource of the WSDLLocator is ignored, instead
-   * the WSDL is parsed from the given Element. 
+   * Read the specified &lt;wsdl:definitions&gt; element into a WSDL definition. The WSDLLocator is used to provide the document base URIs. The InputSource of the WSDLLocator is ignored, instead the WSDL is parsed from the given Element.
    *
-   * @param locator A WSDLLocator object used to provide 
-   * the document base URI of the WSDL definition described by the
-   * element.
-   * @param definitionsElement the &lt;wsdl:definitions&gt; element
+   * @param locator
+   *          A WSDLLocator object used to provide the document base URI of the WSDL definition described by the element.
+   * @param definitionsElement
+   *          the &lt;wsdl:definitions&gt; element
    * @return the definition described by the element.
    */
-  public Definition readWSDL(WSDLLocator locator,
-                             Element definitionsElement)
-                               throws WSDLException
-  {
-    try
-    {
+  public Definition readWSDL(WSDLLocator locator, Element definitionsElement) throws WSDLException {
+    try {
       this.loc = locator;
       return readWSDL(locator.getBaseURI(), definitionsElement, null);
-    }
-    finally
-    {
+    } finally {
       locator.close();
       this.loc = null;
     }
   }
-  
-  protected Definition readWSDL(String documentBaseURI,
-                                Element definitionsElement,
-                                Map importedDefs)
-                                  throws WSDLException
-  {
+
+  protected Definition readWSDL(String documentBaseURI, Element definitionsElement, Map importedDefs) throws WSDLException {
     return parseDefinitions(documentBaseURI, definitionsElement, importedDefs);
   }
 
   /**
    * Read the specified WSDL document into a WSDL definition.
    *
-   * @param documentBaseURI the document base URI of the WSDL definition
-   * described by the document. Will be set as the documentBaseURI
-   * of the returned Definition. Can be null, in which case it
-   * will be ignored.
-   * @param wsdlDocument the WSDL document, an XML
-   * document obeying the WSDL schema.
+   * @param documentBaseURI
+   *          the document base URI of the WSDL definition described by the document. Will be set as the documentBaseURI of the returned Definition. Can be null, in which case it will be ignored.
+   * @param wsdlDocument
+   *          the WSDL document, an XML document obeying the WSDL schema.
    * @return the definition described in the document.
    */
-  public Definition readWSDL(String documentBaseURI, Document wsdlDocument)
-    throws WSDLException
-  {
+  public Definition readWSDL(String documentBaseURI, Document wsdlDocument) throws WSDLException {
     return readWSDL(documentBaseURI, wsdlDocument.getDocumentElement());
   }
 
   /**
    * Read a WSDL document into a WSDL definition.
    *
-   * @param documentBaseURI the document base URI of the WSDL definition
-   * described by the document. Will be set as the documentBaseURI
-   * of the returned Definition. Can be null, in which case it
-   * will be ignored.
-   * @param inputSource an InputSource pointing to the
-   * WSDL document, an XML document obeying the WSDL schema.
-   * @return the definition described in the document pointed to
-   * by the InputSource.
+   * @param documentBaseURI
+   *          the document base URI of the WSDL definition described by the document. Will be set as the documentBaseURI of the returned Definition. Can be null, in which case it will be ignored.
+   * @param inputSource
+   *          an InputSource pointing to the WSDL document, an XML document obeying the WSDL schema.
+   * @return the definition described in the document pointed to by the InputSource.
    */
-  public Definition readWSDL(String documentBaseURI, InputSource inputSource)
-    throws WSDLException
-  {
-    String location = (inputSource.getSystemId() != null ? 
-                       inputSource.getSystemId() : "- WSDL Document -");
-    
-    return readWSDL(documentBaseURI,
-                    getDocument(inputSource, location));
+  public Definition readWSDL(String documentBaseURI, InputSource inputSource) throws WSDLException {
+    String location = (inputSource.getSystemId() != null ? inputSource.getSystemId() : "- WSDL Document -");
+
+    return readWSDL(documentBaseURI, getDocument(inputSource, location));
   }
 
   /**
    * Read a WSDL document into a WSDL definition.
    *
-   * @param locator A WSDLLocator object used to provide InputSources
-   * pointing to the wsdl file.
+   * @param locator
+   *          A WSDLLocator object used to provide InputSources pointing to the wsdl file.
    * @return the definition described in the document
    */
-  public Definition readWSDL(WSDLLocator locator) throws WSDLException
-  {
+  public Definition readWSDL(WSDLLocator locator) throws WSDLException {
     InputSource is = locator.getBaseInputSource();
     String base = locator.getBaseURI();
 
-    if (is == null)
-    {
-      throw new WSDLException(WSDLException.OTHER_ERROR,
-                              "Unable to locate document at '" + base + "'.");
+    if (is == null) {
+      throw new WSDLException(WSDLException.OTHER_ERROR, "Unable to locate document at '" + base + "'.");
     }
     is.setSystemId(base);
 
     this.loc = locator;
 
-    if (verbose)
-    {
+    if (verbose) {
       System.out.println("Retrieving document at '" + base + "'.");
     }
 
-    try
-    {
+    try {
       return readWSDL(base, is);
-    }
-    finally
-    {
+    } finally {
       this.loc.close();
       this.loc = null;
     }

--- a/src/main/java/com/ibm/wsdl/xml/WSDLWriterImpl.java
+++ b/src/main/java/com/ibm/wsdl/xml/WSDLWriterImpl.java
@@ -20,109 +20,86 @@ import com.ibm.wsdl.util.*;
 import com.ibm.wsdl.util.xml.*;
 
 /**
- * This class describes a collection of methods
- * that allow a WSDL model to be written to a writer
- * in an XML format that follows the WSDL schema.
+ * This class describes a collection of methods that allow a WSDL model to be written to a writer in an XML format that follows the WSDL schema.
  *
  * @author Matthew J. Duftler
  * @author Nirmal Mukhi
  */
-public class WSDLWriterImpl implements WSDLWriter
-{
+public class WSDLWriterImpl implements WSDLWriter {
   /**
    * Sets the specified feature to the specified value.
    * <p>
    * There are no minimum features that must be supported.
    * <p>
-   * All feature names must be fully-qualified, Java package style. All
-   * names starting with javax.wsdl. are reserved for features defined
-   * by the JWSDL specification. It is recommended that implementation-
-   * specific features be fully-qualified to match the package name
-   * of that implementation. For example: com.abc.featureName
+   * All feature names must be fully-qualified, Java package style. All names starting with javax.wsdl. are reserved for features defined by the JWSDL specification. It is recommended that implementation- specific features be fully-qualified to match the package name of that implementation. For
+   * example: com.abc.featureName
    *
-   * @param name the name of the feature to be set.
-   * @param value the value to set the feature to.
-   * @throws IllegalArgumentException if the feature name is not recognized.
+   * @param name
+   *          the name of the feature to be set.
+   * @param value
+   *          the value to set the feature to.
+   * @throws IllegalArgumentException
+   *           if the feature name is not recognized.
    * @see #getFeature(String)
    */
-  public void setFeature(String name, boolean value)
-    throws IllegalArgumentException
-  {
-    if (name == null)
-    {
+  public void setFeature(String name, boolean value) throws IllegalArgumentException {
+    if (name == null) {
       throw new IllegalArgumentException("Feature name must not be null.");
-    }
-    else
-    {
-      throw new IllegalArgumentException("Feature name '" + name +
-                                         "' not recognized.");
+    } else {
+      throw new IllegalArgumentException("Feature name '" + name + "' not recognized.");
     }
   }
 
   /**
    * Gets the value of the specified feature.
    *
-   * @param name the name of the feature to get the value of.
+   * @param name
+   *          the name of the feature to get the value of.
    * @return the value of the feature.
-   * @throws IllegalArgumentException if the feature name is not recognized.
+   * @throws IllegalArgumentException
+   *           if the feature name is not recognized.
    * @see #setFeature(String, boolean)
    */
-  public boolean getFeature(String name) throws IllegalArgumentException
-  {
-    if (name == null)
-    {
+  public boolean getFeature(String name) throws IllegalArgumentException {
+    if (name == null) {
       throw new IllegalArgumentException("Feature name must not be null.");
-    }
-    else
-    {
-      throw new IllegalArgumentException("Feature name '" + name +
-                                         "' not recognized.");
+    } else {
+      throw new IllegalArgumentException("Feature name '" + name + "' not recognized.");
     }
   }
 
-  protected void printDefinition(Definition def, PrintWriter pw)
-    throws WSDLException
-  {
-    if (def == null)
-    {
+  protected void printDefinition(Definition def, PrintWriter pw) throws WSDLException {
+    if (def == null) {
       return;
     }
 
-    if (def.getPrefix(Constants.NS_URI_WSDL) == null)
-    {
+    if (def.getPrefix(Constants.NS_URI_WSDL) == null) {
       String prefix = "wsdl";
       int subscript = 0;
 
-      while (def.getNamespace(prefix) != null)
-      {
+      while (def.getNamespace(prefix) != null) {
         prefix = "wsdl" + subscript++;
       }
 
       def.addNamespace(prefix, Constants.NS_URI_WSDL);
     }
 
-    String tagName =
-      DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                 Constants.ELEM_DEFINITIONS,
-                                 def);
+    String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_DEFINITIONS, def);
 
     pw.print('<' + tagName);
 
     QName name = def.getQName();
     String targetNamespace = def.getTargetNamespace();
-    Map namespaces = def.getNamespaces();
+    Map<String, String> namespaces = def.getNamespaces();
 
-    if (name != null)
-    {
+    if (name != null) {
       DOMUtils.printAttribute(Constants.ATTR_NAME, name.getLocalPart(), pw);
     }
 
-    DOMUtils.printAttribute(Constants.ATTR_TARGET_NAMESPACE,
-                            targetNamespace,
-                            pw);
+    DOMUtils.printAttribute(Constants.ATTR_TARGET_NAMESPACE, targetNamespace, pw);
 
-    printExtensibilityAttributes(Definition.class, def, def, pw);
-    
+    printExtensibilityAttributes(def, def, pw);
+
     printNamespaceDeclarations(namespaces, pw);
 
     pw.println('>');
@@ -135,7 +112,7 @@ public class WSDLWriterImpl implements WSDLWriter
     printBindings(def.getBindings(), def, pw);
     printServices(def.getServices(), def, pw);
 
-    List extElements = def.getExtensibilityElements();
+    List<ExtensibilityElement> extElements = def.getExtensibilityElements();
 
     printExtensibilityElements(Definition.class, extElements, def, pw);
 
@@ -144,42 +121,30 @@ public class WSDLWriterImpl implements WSDLWriter
     pw.flush();
   }
 
-  protected void printServices(Map services,
-                               Definition def,
-                               PrintWriter pw)
-                                 throws WSDLException
-  {
-    if (services != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_SERVICE,
-                                   def);
-      Iterator serviceIterator = services.values().iterator();
+  protected void printServices(Map<QName, Service> services, Definition def, PrintWriter pw) throws WSDLException {
+    if (services != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_SERVICE, def);
+      Iterator<Service> serviceIterator = services.values().iterator();
 
-      while (serviceIterator.hasNext())
-      {
-        Service service = (Service)serviceIterator.next();
+      while (serviceIterator.hasNext()) {
+        Service service = serviceIterator.next();
 
         pw.print("  <" + tagName);
 
         QName name = service.getQName();
 
-        if (name != null)
-        {
-          DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                  name.getLocalPart(),
-                                  pw);
+        if (name != null) {
+          DOMUtils.printAttribute(Constants.ATTR_NAME, name.getLocalPart(), pw);
         }
 
-        printExtensibilityAttributes(Service.class, service, def, pw);
-        
+        printExtensibilityAttributes(service, def, pw);
+
         pw.println('>');
 
         printDocumentation(service.getDocumentationElement(), def, pw);
         printPorts(service.getPorts(), def, pw);
 
-        List extElements = service.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = service.getExtensibilityElements();
 
         printExtensibilityElements(Service.class, extElements, def, pw);
 
@@ -188,20 +153,13 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printPorts(Map ports, Definition def, PrintWriter pw)
-    throws WSDLException
-  {
-    if (ports != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_PORT,
-                                   def);
-      Iterator portIterator = ports.values().iterator();
+  protected void printPorts(Map<String, Port> ports, Definition def, PrintWriter pw) throws WSDLException {
+    if (ports != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_PORT, def);
+      Iterator<Port> portIterator = ports.values().iterator();
 
-      while (portIterator.hasNext())
-      {
-        Port port = (Port)portIterator.next();
+      while (portIterator.hasNext()) {
+        Port port = portIterator.next();
 
         pw.print("    <" + tagName);
 
@@ -209,21 +167,17 @@ public class WSDLWriterImpl implements WSDLWriter
 
         Binding binding = port.getBinding();
 
-        if (binding != null)
-        {
-          DOMUtils.printQualifiedAttribute(Constants.ATTR_BINDING,
-                                           binding.getQName(),
-                                           def,
-                                           pw);
+        if (binding != null) {
+          DOMUtils.printQualifiedAttribute(Constants.ATTR_BINDING, binding.getQName(), def, pw);
         }
 
-        printExtensibilityAttributes(Port.class, port, def, pw);
-        
+        printExtensibilityAttributes(port, def, pw);
+
         pw.println('>');
 
         printDocumentation(port.getDocumentationElement(), def, pw);
 
-        List extElements = port.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = port.getExtensibilityElements();
 
         printExtensibilityElements(Port.class, extElements, def, pw);
 
@@ -232,51 +186,34 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printBindings(Map bindings,
-                               Definition def,
-                               PrintWriter pw)
-                                 throws WSDLException
-  {
-    if (bindings != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_BINDING,
-                                   def);
-      Iterator bindingIterator = bindings.values().iterator();
+  protected void printBindings(Map<QName, Binding> bindings, Definition def, PrintWriter pw) throws WSDLException {
+    if (bindings != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_BINDING, def);
+      Iterator<Binding> bindingIterator = bindings.values().iterator();
 
-      while (bindingIterator.hasNext())
-      {
-        Binding binding = (Binding)bindingIterator.next();
+      while (bindingIterator.hasNext()) {
+        Binding binding = bindingIterator.next();
 
-        if (!binding.isUndefined())
-        {
+        if (!binding.isUndefined()) {
           pw.print("  <" + tagName);
 
           QName name = binding.getQName();
 
-          if (name != null)
-          {
-            DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                    name.getLocalPart(),
-                                    pw);
+          if (name != null) {
+            DOMUtils.printAttribute(Constants.ATTR_NAME, name.getLocalPart(), pw);
           }
 
           PortType portType = binding.getPortType();
 
-          if (portType != null)
-          {
-            DOMUtils.printQualifiedAttribute(Constants.ATTR_TYPE,
-                                             portType.getQName(),
-                                             def,
-                                             pw);
+          if (portType != null) {
+            DOMUtils.printQualifiedAttribute(Constants.ATTR_TYPE, portType.getQName(), def, pw);
           }
 
           pw.println('>');
 
           printDocumentation(binding.getDocumentationElement(), def, pw);
 
-          List extElements = binding.getExtensibilityElements();
+          List<ExtensibilityElement> extElements = binding.getExtensibilityElements();
 
           printExtensibilityElements(Binding.class, extElements, def, pw);
 
@@ -288,42 +225,27 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printBindingOperations(List bindingOperations,
-                                        Definition def,
-                                        PrintWriter pw)
-                                          throws WSDLException
-  {
-    if (bindingOperations != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_OPERATION,
-                                   def);
-      Iterator bindingOperationIterator = bindingOperations.iterator();
+  protected void printBindingOperations(List<BindingOperation> bindingOperations, Definition def, PrintWriter pw) throws WSDLException {
+    if (bindingOperations != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_OPERATION, def);
+      Iterator<BindingOperation> bindingOperationIterator = bindingOperations.iterator();
 
-      while (bindingOperationIterator.hasNext())
-      {
-        BindingOperation bindingOperation =
-          (BindingOperation)bindingOperationIterator.next();
+      while (bindingOperationIterator.hasNext()) {
+        BindingOperation bindingOperation = bindingOperationIterator.next();
 
         pw.print("    <" + tagName);
 
-        DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                bindingOperation.getName(),
-                                pw);
-        
-        printExtensibilityAttributes(BindingOperation.class, bindingOperation, def, pw);
+        DOMUtils.printAttribute(Constants.ATTR_NAME, bindingOperation.getName(), pw);
+
+        printExtensibilityAttributes(bindingOperation, def, pw);
 
         pw.println('>');
 
         printDocumentation(bindingOperation.getDocumentationElement(), def, pw);
 
-        List extElements = bindingOperation.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = bindingOperation.getExtensibilityElements();
 
-        printExtensibilityElements(BindingOperation.class,
-                                   extElements,
-                                   def,
-                                   pw);
+        printExtensibilityElements(BindingOperation.class, extElements, def, pw);
 
         printBindingInput(bindingOperation.getBindingInput(), def, pw);
         printBindingOutput(bindingOperation.getBindingOutput(), def, pw);
@@ -334,31 +256,21 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printBindingInput(BindingInput bindingInput,
-                                   Definition def,
-                                   PrintWriter pw)
-                                     throws WSDLException
-  {
-    if (bindingInput != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_INPUT,
-                                   def);
+  protected void printBindingInput(BindingInput bindingInput, Definition def, PrintWriter pw) throws WSDLException {
+    if (bindingInput != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_INPUT, def);
 
       pw.print("      <" + tagName);
 
-      DOMUtils.printAttribute(Constants.ATTR_NAME,
-                              bindingInput.getName(),
-                              pw);
+      DOMUtils.printAttribute(Constants.ATTR_NAME, bindingInput.getName(), pw);
 
-      printExtensibilityAttributes(BindingInput.class, bindingInput, def, pw);
-      
+      printExtensibilityAttributes(bindingInput, def, pw);
+
       pw.println('>');
 
       printDocumentation(bindingInput.getDocumentationElement(), def, pw);
 
-      List extElements = bindingInput.getExtensibilityElements();
+      List<ExtensibilityElement> extElements = bindingInput.getExtensibilityElements();
 
       printExtensibilityElements(BindingInput.class, extElements, def, pw);
 
@@ -366,29 +278,19 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printBindingOutput(BindingOutput bindingOutput,
-                                    Definition def,
-                                    PrintWriter pw)
-                                      throws WSDLException
-  {
-    if (bindingOutput != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_OUTPUT,
-                                   def);
+  protected void printBindingOutput(BindingOutput bindingOutput, Definition def, PrintWriter pw) throws WSDLException {
+    if (bindingOutput != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_OUTPUT, def);
 
       pw.print("      <" + tagName);
 
-      DOMUtils.printAttribute(Constants.ATTR_NAME,
-                              bindingOutput.getName(),
-                              pw);
+      DOMUtils.printAttribute(Constants.ATTR_NAME, bindingOutput.getName(), pw);
 
       pw.println('>');
 
       printDocumentation(bindingOutput.getDocumentationElement(), def, pw);
 
-      List extElements = bindingOutput.getExtensibilityElements();
+      List<ExtensibilityElement> extElements = bindingOutput.getExtensibilityElements();
 
       printExtensibilityElements(BindingOutput.class, extElements, def, pw);
 
@@ -396,36 +298,25 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printBindingFaults(Map bindingFaults,
-                                    Definition def,
-                                    PrintWriter pw)
-                                      throws WSDLException
-  {
-    if (bindingFaults != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_FAULT,
-                                   def);
-      Iterator bindingFaultIterator = bindingFaults.values().iterator();
+  protected void printBindingFaults(Map<String, BindingFault> bindingFaults, Definition def, PrintWriter pw) throws WSDLException {
+    if (bindingFaults != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_FAULT, def);
+      Iterator<BindingFault> bindingFaultIterator = bindingFaults.values().iterator();
 
-      while (bindingFaultIterator.hasNext())
-      {
-        BindingFault bindingFault = (BindingFault)bindingFaultIterator.next();
+      while (bindingFaultIterator.hasNext()) {
+        BindingFault bindingFault = bindingFaultIterator.next();
 
         pw.print("      <" + tagName);
 
-        DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                bindingFault.getName(),
-                                pw);
-        
-        printExtensibilityAttributes(BindingFault.class, bindingFault, def, pw);
+        DOMUtils.printAttribute(Constants.ATTR_NAME, bindingFault.getName(), pw);
+
+        printExtensibilityAttributes(bindingFault, def, pw);
 
         pw.println('>');
 
         printDocumentation(bindingFault.getDocumentationElement(), def, pw);
 
-        List extElements = bindingFault.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = bindingFault.getExtensibilityElements();
 
         printExtensibilityElements(BindingFault.class, extElements, def, pw);
 
@@ -434,112 +325,78 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printPortTypes(Map portTypes,
-                                Definition def,
-                                PrintWriter pw)
-                                  throws WSDLException
-  {
-    if (portTypes != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_PORT_TYPE,
-                                   def);
-      Iterator portTypeIterator = portTypes.values().iterator();
+  protected void printPortTypes(Map<QName, PortType> portTypes, Definition def, PrintWriter pw) throws WSDLException {
+    if (portTypes != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_PORT_TYPE, def);
+      Iterator<PortType> portTypeIterator = portTypes.values().iterator();
 
-      while (portTypeIterator.hasNext())
-      {
-        PortType portType = (PortType)portTypeIterator.next();
+      while (portTypeIterator.hasNext()) {
+        PortType portType = portTypeIterator.next();
 
-        if (!portType.isUndefined())
-        {
+        if (!portType.isUndefined()) {
           pw.print("  <" + tagName);
 
           QName name = portType.getQName();
 
-          if (name != null)
-          {
-            DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                    name.getLocalPart(),
-                                    pw);
+          if (name != null) {
+            DOMUtils.printAttribute(Constants.ATTR_NAME, name.getLocalPart(), pw);
           }
 
-          printExtensibilityAttributes(PortType.class, portType, def, pw);
+          printExtensibilityAttributes(portType, def, pw);
 
           pw.println('>');
 
           printDocumentation(portType.getDocumentationElement(), def, pw);
           printOperations(portType.getOperations(), def, pw);
 
-          List extElements = portType.getExtensibilityElements();
+          List<ExtensibilityElement> extElements = portType.getExtensibilityElements();
           printExtensibilityElements(PortType.class, extElements, def, pw);
-          
+
           pw.println("  </" + tagName + '>');
         }
       }
     }
   }
 
-  protected void printOperations(List operations,
-                                 Definition def,
-                                 PrintWriter pw)
-                                   throws WSDLException
-  {
-    if (operations != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_OPERATION,
-                                   def);
-      Iterator operationIterator = operations.iterator();
+  protected void printOperations(List<Operation> operations, Definition def, PrintWriter pw) throws WSDLException {
+    if (operations != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_OPERATION, def);
+      Iterator<Operation> operationIterator = operations.iterator();
 
-      while (operationIterator.hasNext())
-      {
-        Operation operation = (Operation)operationIterator.next();
+      while (operationIterator.hasNext()) {
+        Operation operation = operationIterator.next();
 
-        if (!operation.isUndefined())
-        {
+        if (!operation.isUndefined()) {
           pw.print("    <" + tagName);
 
-          DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                  operation.getName(),
-                                  pw);
-          DOMUtils.printAttribute(Constants.ATTR_PARAMETER_ORDER,
-                   StringUtils.getNMTokens(operation.getParameterOrdering()),
-                   pw);
+          DOMUtils.printAttribute(Constants.ATTR_NAME, operation.getName(), pw);
+          DOMUtils.printAttribute(Constants.ATTR_PARAMETER_ORDER, StringUtils.getNMTokens(operation.getParameterOrdering()), pw);
 
-          printExtensibilityAttributes(Operation.class, operation, def, pw);
-          
+          printExtensibilityAttributes(operation, def, pw);
+
           pw.println('>');
 
           printDocumentation(operation.getDocumentationElement(), def, pw);
 
           OperationType operationType = operation.getStyle();
 
-          if (operationType == OperationType.ONE_WAY)
-          {
+          if (operationType == OperationType.ONE_WAY) {
             printInput(operation.getInput(), def, pw);
-          }
-          else if (operationType == OperationType.SOLICIT_RESPONSE)
-          {
+          } else if (operationType == OperationType.SOLICIT_RESPONSE) {
             printOutput(operation.getOutput(), def, pw);
             printInput(operation.getInput(), def, pw);
-          }
-          else if (operationType == OperationType.NOTIFICATION)
-          {
+          } else if (operationType == OperationType.NOTIFICATION) {
             printOutput(operation.getOutput(), def, pw);
-          }
-          else
-          {
+          } else {
             // Must be OperationType.REQUEST_RESPONSE.
             printInput(operation.getInput(), def, pw);
             printOutput(operation.getOutput(), def, pw);
           }
 
           printFaults(operation.getFaults(), def, pw);
-          
-          List extElements = operation.getExtensibilityElements();
-          
+
+          List<ExtensibilityElement> extElements = operation.getExtensibilityElements();
+
           printExtensibilityElements(Operation.class, extElements, def, pw);
 
           pw.println("    </" + tagName + '>');
@@ -548,17 +405,9 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printInput(Input input,
-                            Definition def,
-                            PrintWriter pw)
-                              throws WSDLException
-  {
-    if (input != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_INPUT,
-                                   def);
+  protected void printInput(Input input, Definition def, PrintWriter pw) throws WSDLException {
+    if (input != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_INPUT, def);
 
       pw.print("      <" + tagName);
 
@@ -566,21 +415,17 @@ public class WSDLWriterImpl implements WSDLWriter
 
       Message message = input.getMessage();
 
-      if (message != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE,
-                                         message.getQName(),
-                                         def,
-                                         pw);
+      if (message != null) {
+        DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE, message.getQName(), def, pw);
       }
 
-      printExtensibilityAttributes(Input.class, input, def, pw);
+      printExtensibilityAttributes(input, def, pw);
 
       pw.println('>');
 
       printDocumentation(input.getDocumentationElement(), def, pw);
 
-      List extElements = input.getExtensibilityElements();
+      List<ExtensibilityElement> extElements = input.getExtensibilityElements();
 
       printExtensibilityElements(Input.class, extElements, def, pw);
 
@@ -588,17 +433,9 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printOutput(Output output,
-                             Definition def,
-                             PrintWriter pw)
-                               throws WSDLException
-  {
-    if (output != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_OUTPUT,
-                                   def);
+  protected void printOutput(Output output, Definition def, PrintWriter pw) throws WSDLException {
+    if (output != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_OUTPUT, def);
 
       pw.print("      <" + tagName);
 
@@ -606,21 +443,17 @@ public class WSDLWriterImpl implements WSDLWriter
 
       Message message = output.getMessage();
 
-      if (message != null)
-      {
-        DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE,
-                                         message.getQName(),
-                                         def,
-                                         pw);
+      if (message != null) {
+        DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE, message.getQName(), def, pw);
       }
 
-      printExtensibilityAttributes(Output.class, output, def, pw);
+      printExtensibilityAttributes(output, def, pw);
 
       pw.println('>');
 
       printDocumentation(output.getDocumentationElement(), def, pw);
 
-      List extElements = output.getExtensibilityElements();
+      List<ExtensibilityElement> extElements = output.getExtensibilityElements();
 
       printExtensibilityElements(Output.class, extElements, def, pw);
 
@@ -628,22 +461,13 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printFaults(Map faults,
-                             Definition def,
-                             PrintWriter pw)
-                               throws WSDLException
-  {
-    if (faults != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_FAULT,
-                                   def);
-      Iterator faultIterator = faults.values().iterator();
+  protected void printFaults(Map<String, Fault> faults, Definition def, PrintWriter pw) throws WSDLException {
+    if (faults != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_FAULT, def);
+      Iterator<Fault> faultIterator = faults.values().iterator();
 
-      while (faultIterator.hasNext())
-      {
-        Fault fault = (Fault)faultIterator.next();
+      while (faultIterator.hasNext()) {
+        Fault fault = faultIterator.next();
 
         pw.print("      <" + tagName);
 
@@ -651,21 +475,17 @@ public class WSDLWriterImpl implements WSDLWriter
 
         Message message = fault.getMessage();
 
-        if (message != null)
-        {
-          DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE,
-                                           message.getQName(),
-                                           def,
-                                           pw);
+        if (message != null) {
+          DOMUtils.printQualifiedAttribute(Constants.ATTR_MESSAGE, message.getQName(), def, pw);
         }
 
-        printExtensibilityAttributes(Fault.class, fault, def, pw);
+        printExtensibilityAttributes(fault, def, pw);
 
         pw.println('>');
 
         printDocumentation(fault.getDocumentationElement(), def, pw);
 
-        List extElements = fault.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = fault.getExtensibilityElements();
 
         printExtensibilityElements(Fault.class, extElements, def, pw);
 
@@ -674,45 +494,32 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printMessages(Map messages,
-                               Definition def,
-                               PrintWriter pw)
-                                 throws WSDLException
-  {
-    if (messages != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_MESSAGE,
-                                   def);
-      Iterator messageIterator = messages.values().iterator();
+  protected void printMessages(Map<QName, Message> messages, Definition def, PrintWriter pw) throws WSDLException {
+    if (messages != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_MESSAGE, def);
+      Iterator<Message> messageIterator = messages.values().iterator();
 
-      while (messageIterator.hasNext())
-      {
-        Message message = (Message)messageIterator.next();
+      while (messageIterator.hasNext()) {
+        Message message = messageIterator.next();
 
-        if (!message.isUndefined())
-        {
+        if (!message.isUndefined()) {
           pw.print("  <" + tagName);
 
           QName name = message.getQName();
 
-          if (name != null)
-          {
-            DOMUtils.printAttribute(Constants.ATTR_NAME,
-                                    name.getLocalPart(),
-                                    pw);
+          if (name != null) {
+            DOMUtils.printAttribute(Constants.ATTR_NAME, name.getLocalPart(), pw);
           }
 
-          printExtensibilityAttributes(Message.class, message, def, pw);
-          
+          printExtensibilityAttributes(message, def, pw);
+
           pw.println('>');
 
           printDocumentation(message.getDocumentationElement(), def, pw);
           printParts(message.getOrderedParts(null), def, pw);
-          
-          List extElements = message.getExtensibilityElements();
-          
+
+          List<ExtensibilityElement> extElements = message.getExtensibilityElements();
+
           printExtensibilityElements(Message.class, extElements, def, pw);
 
           pw.println("  </" + tagName + '>');
@@ -721,40 +528,27 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printParts(List parts, Definition def, PrintWriter pw)
-    throws WSDLException
-  {
-    if (parts != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_PART,
-                                   def);
-      Iterator partIterator = parts.iterator();
+  protected void printParts(List<Part> parts, Definition def, PrintWriter pw) throws WSDLException {
+    if (parts != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_PART, def);
+      Iterator<Part> partIterator = parts.iterator();
 
-      while (partIterator.hasNext())
-      {
-        Part part = (Part)partIterator.next();
+      while (partIterator.hasNext()) {
+        Part part = partIterator.next();
 
         pw.print("    <" + tagName);
 
         DOMUtils.printAttribute(Constants.ATTR_NAME, part.getName(), pw);
-        DOMUtils.printQualifiedAttribute(Constants.ATTR_ELEMENT,
-                                         part.getElementName(),
-                                         def,
-                                         pw);
-        DOMUtils.printQualifiedAttribute(Constants.ATTR_TYPE,
-                                         part.getTypeName(),
-                                         def,
-                                         pw);
+        DOMUtils.printQualifiedAttribute(Constants.ATTR_ELEMENT, part.getElementName(), def, pw);
+        DOMUtils.printQualifiedAttribute(Constants.ATTR_TYPE, part.getTypeName(), def, pw);
 
-        printExtensibilityAttributes(Part.class, part, def, pw);
+        printExtensibilityAttributes(part, def, pw);
 
         pw.println('>');
 
         printDocumentation(part.getDocumentationElement(), def, pw);
 
-        List extElements = part.getExtensibilityElements();
+        List<ExtensibilityElement> extElements = part.getExtensibilityElements();
 
         printExtensibilityElements(Part.class, extElements, def, pw);
 
@@ -763,122 +557,74 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printExtensibilityAttributes(Class parentType,
-                                              AttributeExtensible attrExt,
-                                              Definition def,
-                                              PrintWriter pw)
-                                                throws WSDLException
-  {
-    Map extensionAttributes = attrExt.getExtensionAttributes();
-    Iterator attrNames = extensionAttributes.keySet().iterator();
-
-    while (attrNames.hasNext())
-    {
-      QName attrName = (QName)attrNames.next();
-      Object attrValue = extensionAttributes.get(attrName);
+  protected void printExtensibilityAttributes(AttributeExtensible attrExt, Definition def, PrintWriter pw) throws WSDLException {
+    Map<QName, Object> extensionAttributes = attrExt.getExtensionAttributes();
+    for (Map.Entry<QName, Object> attribute : extensionAttributes.entrySet()) {
+      QName attrName = attribute.getKey();
+      Object attrValue = attribute.getValue();
       String attrStrValue = null;
       QName attrQNameValue = null;
 
-      if (attrValue instanceof String)
-      {
-        attrStrValue = (String)attrValue;
-      }
-      else if (attrValue instanceof QName)
-      {
-        attrQNameValue = (QName)attrValue;
-      }
-      else if (attrValue instanceof List)
-      {
-        List attrValueList = (List)attrValue;
+      if (attrValue instanceof String) {
+        attrStrValue = (String) attrValue;
+      } else if (attrValue instanceof QName) {
+        attrQNameValue = (QName) attrValue;
+      } else if (attrValue instanceof List) {
+        List<?> attrValueList = (List<?>) attrValue;
         int size = attrValueList.size();
 
-        if (size > 0)
-        {
+        if (size > 0) {
           Object tempAttrVal = attrValueList.get(0);
 
-          if (tempAttrVal instanceof String)
-          {
-            attrStrValue = StringUtils.getNMTokens(attrValueList);
-          }
-          else if (tempAttrVal instanceof QName)
-          {
-            StringBuffer strBuf = new StringBuffer();
+          if (tempAttrVal instanceof String) {
+            attrStrValue = StringUtils.getNMTokens((List<String>) attrValueList);
+          } else if (tempAttrVal instanceof QName) {
+            StringBuilder strBuf = new StringBuilder();
 
-            for (int i = 0; i < size; i++)
-            {
-              QName tempQName = (QName)attrValueList.get(i);
+            for (int i = 0; i < size; i++) {
+              QName tempQName = (QName) attrValueList.get(i);
 
-              strBuf.append((i > 0 ? " " : "") +
-                            DOMUtils.getQualifiedValue(tempQName.getNamespaceURI(),
-                                                       tempQName.getLocalPart(),
-                                                       def));
+              strBuf.append((i > 0 ? " " : "") + DOMUtils.getQualifiedValue(tempQName.getNamespaceURI(), tempQName.getLocalPart(), def));
             }
 
             attrStrValue = strBuf.toString();
+          } else {
+            throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Unknown type of extension attribute '" + attrName + "': " + tempAttrVal.getClass().getName());
           }
-          else
-          {
-            throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                    "Unknown type of extension attribute '" +
-                                    attrName + "': " +
-                                    tempAttrVal.getClass().getName());
-          }
-        }
-        else
-        {
+        } else {
           attrStrValue = "";
         }
-      }
-      else
-      {
-        throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                "Unknown type of extension attribute '" +
-                                attrName + "': " +
-                                attrValue.getClass().getName());
+      } else {
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Unknown type of extension attribute '" + attrName + "': " + attrValue.getClass().getName());
       }
 
-      if (attrQNameValue != null)
-      {
+      if (attrQNameValue != null) {
         DOMUtils.printQualifiedAttribute(attrName, attrQNameValue, def, pw);
-      }
-      else
-      {
+      } else {
         DOMUtils.printQualifiedAttribute(attrName, attrStrValue, def, pw);
       }
     }
   }
 
-  protected void printDocumentation(Element docElement,
-                                    Definition def,
-                                    PrintWriter pw)
-                                      throws WSDLException
-  {
-    if (docElement != null)
-    {
+  protected void printDocumentation(Element docElement, Definition def, PrintWriter pw) {
+    if (docElement != null) {
       DOM2Writer.serializeAsXML(docElement, def.getNamespaces(), pw);
-
       pw.println();
     }
   }
 
-  protected void printTypes(Types types, Definition def, PrintWriter pw)
-    throws WSDLException
-  {
-    if (types != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_TYPES,
-                                   def);
+  protected void printTypes(Types types, Definition def, PrintWriter pw) throws WSDLException {
+    if (types != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_TYPES, def);
       pw.print("  <" + tagName);
 
-      printExtensibilityAttributes(Types.class, types, def, pw);
-      
+      printExtensibilityAttributes(types, def, pw);
+
       pw.println('>');
 
       printDocumentation(types.getDocumentationElement(), def, pw);
 
-      List extElements = types.getExtensibilityElements();
+      List<ExtensibilityElement> extElements = types.getExtensibilityElements();
 
       printExtensibilityElements(Types.class, extElements, def, pw);
 
@@ -886,42 +632,30 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printImports(Map imports, Definition def, PrintWriter pw)
-    throws WSDLException
-  {
-    if (imports != null)
-    {
-      String tagName =
-        DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL,
-                                   Constants.ELEM_IMPORT,
-                                   def);
-      Iterator importListIterator = imports.values().iterator();
+  protected void printImports(Map<String, List<Import>> imports, Definition def, PrintWriter pw) throws WSDLException {
+    if (imports != null) {
+      String tagName = DOMUtils.getQualifiedValue(Constants.NS_URI_WSDL, Constants.ELEM_IMPORT, def);
+      Iterator<List<Import>> importListIterator = imports.values().iterator();
 
-      while (importListIterator.hasNext())
-      {
-        List importList = (List)importListIterator.next();
-        Iterator importIterator = importList.iterator();
+      while (importListIterator.hasNext()) {
+        List<Import> importList = importListIterator.next();
+        Iterator<Import> importIterator = importList.iterator();
 
-        while (importIterator.hasNext())
-        {
-          Import importDef = (Import)importIterator.next();
+        while (importIterator.hasNext()) {
+          Import importDef = importIterator.next();
 
           pw.print("  <" + tagName);
 
-          DOMUtils.printAttribute(Constants.ATTR_NAMESPACE,
-                                  importDef.getNamespaceURI(),
-                                  pw);
-          DOMUtils.printAttribute(Constants.ATTR_LOCATION,
-                                  importDef.getLocationURI(),
-                                  pw);
+          DOMUtils.printAttribute(Constants.ATTR_NAMESPACE, importDef.getNamespaceURI(), pw);
+          DOMUtils.printAttribute(Constants.ATTR_LOCATION, importDef.getLocationURI(), pw);
 
-          printExtensibilityAttributes(Import.class, importDef, def, pw);
+          printExtensibilityAttributes(importDef, def, pw);
 
           pw.println('>');
 
           printDocumentation(importDef.getDocumentationElement(), def, pw);
 
-          List extElements = importDef.getExtensibilityElements();
+          List<ExtensibilityElement> extElements = importDef.getExtensibilityElements();
 
           printExtensibilityElements(Import.class, extElements, def, pw);
 
@@ -931,108 +665,70 @@ public class WSDLWriterImpl implements WSDLWriter
     }
   }
 
-  protected void printNamespaceDeclarations(Map namespaces,
-                                            PrintWriter pw)
-                                              throws WSDLException
-  {
-    if (namespaces != null)
-    {
-      Set keys = namespaces.keySet();
-      Iterator keyIterator = keys.iterator();
+  protected void printNamespaceDeclarations(Map<String, String> namespaces, PrintWriter pw) {
+    if (namespaces != null) {
+      Set<String> keys = namespaces.keySet();
+      Iterator<String> keyIterator = keys.iterator();
 
-      while (keyIterator.hasNext())
-      {
-        String prefix = (String)keyIterator.next();
+      while (keyIterator.hasNext()) {
+        String prefix = keyIterator.next();
 
-        if (prefix == null)
-        {
+        if (prefix == null) {
           prefix = "";
         }
 
-        DOMUtils.printAttribute(Constants.ATTR_XMLNS +
-                                (!prefix.equals("") ? ":" + prefix : ""),
-                                (String)namespaces.get(prefix),
-                                pw);
+        DOMUtils.printAttribute(Constants.ATTR_XMLNS + (!prefix.equals("") ? ":" + prefix : ""), namespaces.get(prefix), pw);
       }
     }
   }
 
-  protected void printExtensibilityElements(Class parentType,
-                                            List extensibilityElements,
-                                            Definition def,
-                                            PrintWriter pw)
-                                              throws WSDLException
-  {
-    if (extensibilityElements != null)
-    {
-      Iterator extensibilityElementIterator = extensibilityElements.iterator();
+  protected void printExtensibilityElements(Class<?> parentType, List<ExtensibilityElement> extensibilityElements, Definition def, PrintWriter pw) throws WSDLException {
+    if (extensibilityElements != null) {
+      Iterator<ExtensibilityElement> extensibilityElementIterator = extensibilityElements.iterator();
 
-      while (extensibilityElementIterator.hasNext())
-      {
-        ExtensibilityElement ext =
-          (ExtensibilityElement)extensibilityElementIterator.next();
+      while (extensibilityElementIterator.hasNext()) {
+        ExtensibilityElement ext = extensibilityElementIterator.next();
         QName elementType = ext.getElementType();
         ExtensionRegistry extReg = def.getExtensionRegistry();
 
-        if (extReg == null)
-        {
-          throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                  "No ExtensionRegistry set for this " +
-                                  "Definition, so unable to serialize a '" +
-                                  elementType +
-                                  "' element in the context of a '" +
-                                  parentType.getName() + "'.");
+        if (extReg == null) {
+          throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionRegistry set for this " + "Definition, so unable to serialize a '" + elementType + "' element in the context of a '" + parentType.getName() + "'.");
         }
-        
+
         // If the wsdl was parsed using the parseSchema feature set to false
-        // then the extensibility will be an UnknownExtensibilityElement rather 
+        // then the extensibility will be an UnknownExtensibilityElement rather
         // than a schema. Serialize this using the default serializer.
         ExtensionSerializer extSer;
-        if (ext instanceof UnknownExtensibilityElement) 
-        {
+        if (ext instanceof UnknownExtensibilityElement) {
           extSer = extReg.getDefaultSerializer();
-        } 
-        else 
-        {        	
-          extSer = extReg.querySerializer(parentType,elementType);
+        } else {
+          extSer = extReg.querySerializer(parentType, elementType);
         }
         extSer.marshall(parentType, elementType, ext, pw, def, extReg);
       }
     }
   }
 
-  private static Document getDocument(InputSource inputSource,
-                                      String desc) throws WSDLException
-  {
+  private static Document getDocument(InputSource inputSource, String desc) throws WSDLException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
     factory.setNamespaceAware(true);
     factory.setValidating(false);
 
-    try
-    {
+    try {
       DocumentBuilder builder = factory.newDocumentBuilder();
-      Document doc = builder.parse(inputSource);
-
-      return doc;
-    }
-    catch (RuntimeException e)
-    {
+      return builder.parse(inputSource);
+    } catch (RuntimeException e) {
       throw e;
-    }
-    catch (Exception e)
-    {
-      throw new WSDLException(WSDLException.PARSER_ERROR,
-                              "Problem parsing '" + desc + "'.",
-                              e);
+    } catch (Exception e) {
+      throw new WSDLException(WSDLException.PARSER_ERROR, "Problem parsing '" + desc + "'.", e);
     }
   }
 
   /**
    * Return a document generated from the specified WSDL model.
    */
-  public Document getDocument(Definition wsdlDef) throws WSDLException
-  {
+  public Document getDocument(Definition wsdlDef) throws WSDLException {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
 
@@ -1047,29 +743,22 @@ public class WSDLWriterImpl implements WSDLWriter
   /**
    * Write the specified WSDL definition to the specified Writer.
    *
-   * @param wsdlDef the WSDL definition to be written.
-   * @param sink the Writer to write the xml to.
+   * @param wsdlDef
+   *          the WSDL definition to be written.
+   * @param sink
+   *          the Writer to write the xml to.
    */
-  public void writeWSDL(Definition wsdlDef, Writer sink)
-    throws WSDLException
-  {
+  public void writeWSDL(Definition wsdlDef, Writer sink) throws WSDLException {
     PrintWriter pw = new PrintWriter(sink);
-    String javaEncoding = (sink instanceof OutputStreamWriter)
-                          ? ((OutputStreamWriter)sink).getEncoding()
-                          : null;
+    String javaEncoding = (sink instanceof OutputStreamWriter) ? ((OutputStreamWriter) sink).getEncoding() : null;
 
-    String xmlEncoding = DOM2Writer.java2XMLEncoding(javaEncoding);                      
+    String xmlEncoding = DOM2Writer.java2XMLEncoding(javaEncoding);
 
-    if (xmlEncoding == null)
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "Unsupported Java encoding for writing " +
-                              "wsdl file: '" + javaEncoding + "'.");
+    if (xmlEncoding == null) {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Unsupported Java encoding for writing " + "wsdl file: '" + javaEncoding + "'.");
     }
 
-    pw.println(Constants.XML_DECL_START +
-               xmlEncoding +
-               Constants.XML_DECL_END);
+    pw.println(Constants.XML_DECL_START + xmlEncoding + Constants.XML_DECL_END);
 
     printDefinition(wsdlDef, pw);
   }
@@ -1077,12 +766,12 @@ public class WSDLWriterImpl implements WSDLWriter
   /**
    * Write the specified WSDL definition to the specified OutputStream.
    *
-   * @param wsdlDef the WSDL definition to be written.
-   * @param sink the OutputStream to write the xml to.
+   * @param wsdlDef
+   *          the WSDL definition to be written.
+   * @param sink
+   *          the OutputStream to write the xml to.
    */
-  public void writeWSDL(Definition wsdlDef, OutputStream sink)
-    throws WSDLException
-  {
+  public void writeWSDL(Definition wsdlDef, OutputStream sink) throws WSDLException {
     Writer writer = null;
 
     writer = new OutputStreamWriter(sink, StandardCharsets.UTF_8);
@@ -1091,39 +780,38 @@ public class WSDLWriterImpl implements WSDLWriter
   }
 
   /**
-   * A test driver.
-   *<code>
-   *<pre>Usage:</pre>
-   *<p>
-   *<pre>  java com.ibm.wsdl.xml.WSDLWriterImpl filename|URL</pre>
-   *<p>
-   *<pre>    This test driver simply reads a WSDL document into a model
+   * A test driver. <code>
+   * 
+   * <pre>
+   * Usage:
+   * </pre>
+   * <p>
+   * 
+   * <pre>
+   *   java com.ibm.wsdl.xml.WSDLWriterImpl filename|URL
+   * </pre>
+   * <p>
+   * 
+   * <pre>
+   *     This test driver simply reads a WSDL document into a model
    *    (using a WSDLReader), and then serializes it back to
    *    standard out. In effect, it performs a round-trip test on
-   *    the specified WSDL document.</pre>
+   *    the specified WSDL document.
+   * </pre>
    */
-  public static void main(String[] argv) throws WSDLException
-  {
-    if (argv.length == 1)
-    {
+  public static void main(String[] argv) throws WSDLException {
+    if (argv.length == 1) {
       WSDLFactory wsdlFactory = WSDLFactory.newInstance();
-      WSDLReader  wsdlReader  = wsdlFactory.newWSDLReader();
-      WSDLWriter  wsdlWriter  = wsdlFactory.newWSDLWriter();
+      WSDLReader wsdlReader = wsdlFactory.newWSDLReader();
+      WSDLWriter wsdlWriter = wsdlFactory.newWSDLWriter();
 
       wsdlWriter.writeWSDL(wsdlReader.readWSDL(null, argv[0]), System.out);
-    }
-    else
-    {
+    } else {
       System.err.println("Usage:");
       System.err.println();
-      System.err.println("  java " + WSDLWriterImpl.class.getName() +
-                         " filename|URL");
+      System.err.println("  java " + WSDLWriterImpl.class.getName() + " filename|URL");
       System.err.println();
-      System.err.println("This test driver simply reads a WSDL document " +
-                         "into a model (using a WSDLReader), and then " +
-                         "serializes it back to standard out. In effect, " +
-                         "it performs a round-trip test on the specified " +
-                         "WSDL document.");
+      System.err.println("This test driver simply reads a WSDL document into a model (using a WSDLReader), and then serializes it back to standard out. In effect, it performs a round-trip test on the specified " + "WSDL document.");
     }
   }
 }

--- a/src/main/java/javax/wsdl/Binding.java
+++ b/src/main/java/javax/wsdl/Binding.java
@@ -92,7 +92,7 @@ public interface Binding extends WSDLElement
   /**
    * Get all the operation bindings defined here.
    */
-  List getBindingOperations();
+  List<BindingOperation> getBindingOperations();
 
   /**
    * Remove the specified operation binding. Note that operation names can

--- a/src/main/java/javax/wsdl/BindingOperation.java
+++ b/src/main/java/javax/wsdl/BindingOperation.java
@@ -101,6 +101,6 @@ public interface BindingOperation extends WSDLElement
    *
    * @return names of fault bindings
    */
-  Map getBindingFaults();
+  Map<String, BindingFault> getBindingFaults();
 
 }

--- a/src/main/java/javax/wsdl/Definition.java
+++ b/src/main/java/javax/wsdl/Definition.java
@@ -112,7 +112,7 @@ public interface Definition extends WSDLElement
     *
     * @see #addNamespace(String, String)
     */
-   Map getNamespaces();
+   Map<String, String> getNamespaces();
 
   /**
    * Set the types section.
@@ -149,7 +149,7 @@ public interface Definition extends WSDLElement
    * @return a list of the corresponding imports, or null if
    * there weren't any matching imports
    */
-  List getImports(String namespaceURI);
+  List<Import> getImports(String namespaceURI);
 
   /**
    * Get a map of lists containing all the imports defined here.
@@ -157,7 +157,7 @@ public interface Definition extends WSDLElement
    * are lists. There is one list for each namespaceURI for which
    * imports have been defined.
    */
-  Map getImports();
+  Map<String, List<Import>> getImports();
 
   /**
    * Add a message to this WSDL description.
@@ -187,7 +187,7 @@ public interface Definition extends WSDLElement
   /**
    * Get all the messages defined here.
    */
-  Map getMessages();
+  Map<QName, Message> getMessages();
 
   /**
    * Add a binding to this WSDL description.
@@ -217,13 +217,13 @@ public interface Definition extends WSDLElement
   /**
    * Get all the bindings defined in this Definition.
    */
-  Map getBindings();
+  Map<QName, Binding>  getBindings();
   
   /**
    * Get all the bindings defined in this Definition and
    * those in any imported Definitions down the WSDL tree.
    */
-  Map getAllBindings();
+  Map<QName, Binding>  getAllBindings();
 
   /**
    * Add a portType to this WSDL description.
@@ -253,13 +253,13 @@ public interface Definition extends WSDLElement
   /**
    * Get all the portTypes defined in this Definition.
    */
-  Map getPortTypes();
+  Map<QName, PortType> getPortTypes();
 
   /**
    * Get all the portTypes defined in this Definition and
    * those in any imported Definitions down the WSDL tree.
    */
-  Map getAllPortTypes();
+  Map<QName, PortType> getAllPortTypes();
   
   /**
    * Add a service to this WSDL description.
@@ -289,13 +289,13 @@ public interface Definition extends WSDLElement
   /**
    * Get all the services defined in this Definition.
    */
-  Map getServices();
+  Map<QName, Service> getServices();
 
   /**
    * Get all the services defined in this Definition and
    * those in any imported Definitions down the WSDL tree.
    */
-  Map getAllServices();
+  Map<QName, Service> getAllServices();
   
   /**
    * Create a new binding.

--- a/src/main/java/javax/wsdl/Message.java
+++ b/src/main/java/javax/wsdl/Message.java
@@ -57,7 +57,7 @@ public interface Message extends WSDLElement
   /**
    * Get all the parts defined here.
    */
-  Map getParts();
+  Map<String, Part> getParts();
 
   /**
    * Get an ordered list of parts as specified by the partOrder
@@ -68,7 +68,7 @@ public interface Message extends WSDLElement
    * returned in the order in which they were added to the message.
    * @return the list of parts
    */
-  List getOrderedParts(List partOrder);
+  List<Part> getOrderedParts(List<String> partOrder);
 
   void setUndefined(boolean isUndefined);
 

--- a/src/main/java/javax/wsdl/Operation.java
+++ b/src/main/java/javax/wsdl/Operation.java
@@ -6,6 +6,8 @@ package javax.wsdl;
 
 import java.util.*;
 
+import javax.xml.namespace.QName;
+
 /**
  * This interface represents a WSDL operation.
  * It includes information on input, output and fault
@@ -89,7 +91,7 @@ public interface Operation extends WSDLElement
    *
    * @return names of fault messages
    */
-  Map getFaults();
+  Map<String, Fault> getFaults();
 
   /**
    * Set the style for this operation (request-response,
@@ -114,7 +116,7 @@ public interface Operation extends WSDLElement
    * containing the part names to reflect the desired
    * order of parameters for RPC-style operations
    */
-  void setParameterOrdering(List parameterOrder);
+  void setParameterOrdering(List<String> parameterOrder);
 
   /**
    * Get the parameter ordering for this operation.
@@ -122,7 +124,7 @@ public interface Operation extends WSDLElement
    * @return the parameter ordering, a list consisting
    * of message part names
    */
-  List getParameterOrdering();
+  List<String> getParameterOrdering();
 
   void setUndefined(boolean isUndefined);
 

--- a/src/main/java/javax/wsdl/OperationType.java
+++ b/src/main/java/javax/wsdl/OperationType.java
@@ -7,73 +7,53 @@ package javax.wsdl;
 import java.io.ObjectStreamException;
 
 /**
- * This class represents an operation type which can
- * be one of request-response, solicit response, one way or
- * notification. This represents a safe way to prevent usage
- * of invalid values since the only objects of this class available
- * are the public static instances declared within the class.
- * Need to figure out if this should be made into an interface.
+ * This class represents an operation type which can be one of request-response, solicit response, one way or notification. This represents a safe way to prevent usage of invalid values since the only objects of this class available are the public static instances declared within the class. Need to
+ * figure out if this should be made into an interface.
  */
-public class OperationType implements java.io.Serializable
-{
+public class OperationType implements java.io.Serializable {
   private final String id;
   private final int intId;
-  
+
   private static int counter = 0;
-  
+
   public static final long serialVersionUID = 1;
 
-  public static OperationType ONE_WAY =
-    new OperationType("ONE_WAY");
-  public static OperationType REQUEST_RESPONSE =
-    new OperationType("REQUEST_RESPONSE");
-  public static OperationType SOLICIT_RESPONSE =
-    new OperationType("SOLICIT_RESPONSE");
-  public static OperationType NOTIFICATION =
-    new OperationType("NOTIFICATION");
-  //If new values of op type are ever added (highly unlikely) 
-  //they must be added here, after the existing values. Otherwise
-  //readResolve will return the wrong instances at deserialization.
+  public static final OperationType ONE_WAY = new OperationType("ONE_WAY");
+  public static final OperationType REQUEST_RESPONSE = new OperationType("REQUEST_RESPONSE");
+  public static final OperationType SOLICIT_RESPONSE = new OperationType("SOLICIT_RESPONSE");
+  public static final OperationType NOTIFICATION = new OperationType("NOTIFICATION");
+  // If new values of op type are ever added (highly unlikely)
+  // they must be added here, after the existing values. Otherwise
+  // readResolve will return the wrong instances at deserialization.
 
-  private static final OperationType[] INSTANCES = 
-      {ONE_WAY, REQUEST_RESPONSE, SOLICIT_RESPONSE, NOTIFICATION};
+  private static final OperationType[] INSTANCES = { ONE_WAY, REQUEST_RESPONSE, SOLICIT_RESPONSE, NOTIFICATION };
 
-  private OperationType(String id)
-  {
-	  this.id = id;
-	  this.intId = counter++;
-  }  
+  private OperationType(String id) {
+    this.id = id;
+    this.intId = counter++;
+  }
 
-  private String getId()
-  {
-	  return id;
-  }  
+  private String getId() {
+    return id;
+  }
 
-  /* The following equals method is not used within wsdl4j but
-   * it is historically part of the jsr110 jwsdl API, so it 
-   * will not likely be removed. Although it overloads the 
-   * Object.equals method (i.e. it has a different arg) it does 
-   * not override it, so Object.equals will still be used by
-   * the readResolve method at deserialization.   
+  /*
+   * The following equals method is not used within wsdl4j but it is historically part of the jsr110 jwsdl API, so it will not likely be removed. Although it overloads the Object.equals method (i.e. it has a different arg) it does not override it, so Object.equals will still be used by the
+   * readResolve method at deserialization.
    */
-  public boolean equals(OperationType operationType)
-  {
+  public boolean equals(OperationType operationType) {
     return operationType != null && id.equals(operationType.getId());
   }
 
-  public String toString()
-  {
+  public String toString() {
     return id + "," + intId;
   }
-  
-  /* The readResolve method has been added because this class
-   * implements a typesafe enumeration and it is serializable. 
-   * This method will ensure that at deserialization the orginal
-   * instances of the enumeration are used, so that Object.equals 
-   * and the '==' operator behave as expected.  
+
+  /*
+   * The readResolve method has been added because this class implements a typesafe enumeration and it is serializable. This method will ensure that at deserialization the orginal instances of the enumeration are used, so that Object.equals and the '==' operator behave as expected.
    */
   private Object readResolve() throws ObjectStreamException {
-      return INSTANCES[intId];
+    return INSTANCES[intId];
   }
-  
+
 }

--- a/src/main/java/javax/wsdl/PortType.java
+++ b/src/main/java/javax/wsdl/PortType.java
@@ -78,7 +78,7 @@ public interface PortType extends WSDLElement
   /**
    * Get all the operations defined here.
    */
-  List getOperations();
+  List<Operation> getOperations();
 
   /**
    * Remove the specified operation. Note that operation names can

--- a/src/main/java/javax/wsdl/Service.java
+++ b/src/main/java/javax/wsdl/Service.java
@@ -58,5 +58,5 @@ public interface Service extends WSDLElement
   /**
    * Get all the ports defined here.
    */
-  Map getPorts();
+  Map<String, Port> getPorts();
 }

--- a/src/main/java/javax/wsdl/extensions/AttributeExtensible.java
+++ b/src/main/java/javax/wsdl/extensions/AttributeExtensible.java
@@ -66,7 +66,7 @@ public interface AttributeExtensible
    * @see ExtensionRegistry#registerExtensionAttributeType
    * @see ExtensionRegistry#queryExtensionAttributeType
    */
-  Map getExtensionAttributes();
+  Map<QName, Object> getExtensionAttributes();
 
   /**
    * Get the list of local attribute names defined for this element in
@@ -74,5 +74,5 @@ public interface AttributeExtensible
    *
    * @return a List of Strings, one for each local attribute name
    */
-  List getNativeAttributeNames();
+  List<String> getNativeAttributeNames();
 }

--- a/src/main/java/javax/wsdl/extensions/ElementExtensible.java
+++ b/src/main/java/javax/wsdl/extensions/ElementExtensible.java
@@ -4,8 +4,7 @@
 
 package javax.wsdl.extensions;
 
-import java.util.*;
-import javax.wsdl.extensions.ExtensibilityElement;
+import java.util.List;
 
 /**
  * Classes that implement this interface can contain extensibility
@@ -33,7 +32,7 @@ public interface ElementExtensible {
     /**
      * Get all the extensibility elements defined here.
      */
-    List getExtensibilityElements();
+    List<ExtensibilityElement> getExtensibilityElements();
 
 
 }

--- a/src/main/java/javax/wsdl/extensions/ExtensionDeserializer.java
+++ b/src/main/java/javax/wsdl/extensions/ExtensionDeserializer.java
@@ -34,7 +34,7 @@ public interface ExtensionDeserializer
    * encountered in
    * @param extReg the ExtensionRegistry to use (if needed again)
    */
-  ExtensibilityElement unmarshall(Class parentType,
+  ExtensibilityElement unmarshall(Class<?> parentType,
                                   QName elementType,
                                   Element el,
                                   Definition def,

--- a/src/main/java/javax/wsdl/extensions/ExtensionRegistry.java
+++ b/src/main/java/javax/wsdl/extensions/ExtensionRegistry.java
@@ -9,450 +9,288 @@ import javax.wsdl.*;
 import javax.xml.namespace.*;
 
 /**
- * This class is used to associate serializers, deserializers, and
- * Java implementation types with extensibility elements.
+ * This class is used to associate serializers, deserializers, and Java implementation types with extensibility elements.
  *
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class ExtensionRegistry implements java.io.Serializable
-{
+public class ExtensionRegistry implements java.io.Serializable {
   public static final long serialVersionUID = 1;
 
   /**
-   * Creates the extension registry, and sets the defaultSerializer
-   * and defaultDeserializer properties to instances of an
-   * UnknownExtensionSerializer, and an UnknownExtensionDeserializer,
-   * respectively.
+   * Creates the extension registry, and sets the defaultSerializer and defaultDeserializer properties to instances of an UnknownExtensionSerializer, and an UnknownExtensionDeserializer, respectively.
    */
-  public ExtensionRegistry()
-  {
+  public ExtensionRegistry() {
     setDefaultSerializer(new UnknownExtensionSerializer());
     setDefaultDeserializer(new UnknownExtensionDeserializer());
   }
 
   /*
-    This is a Map of Maps. The top-level Map is keyed by (Class)parentType,
-    and the inner Maps are keyed by (QName)elementType.
-  */
-  protected Map serializerReg = new Hashtable();
+   * This is a Map of Maps. The top-level Map is keyed by (Class)parentType, and the inner Maps are keyed by (QName)elementType.
+   */
+  private Map<Class<?>, Map<QName, ExtensionSerializer>> serializerReg = new HashMap<>();
   /*
-    This is a Map of Maps. The top-level Map is keyed by (Class)parentType,
-    and the inner Maps are keyed by (QName)elementType.
-  */
-  protected Map deserializerReg = new Hashtable();
+   * This is a Map of Maps. The top-level Map is keyed by (Class)parentType, and the inner Maps are keyed by (QName)elementType.
+   */
+  private Map<Class<?>, Map<QName, ExtensionDeserializer>> deserializerReg = new HashMap<>();
   /*
-    This is a Map of Maps. The top-level Map is keyed by (Class)parentType,
-    and the inner Maps are keyed by (QName)elementType.
-  */
-  protected Map extensionTypeReg = new Hashtable();
-  protected ExtensionSerializer defaultSer = null;
-  protected ExtensionDeserializer defaultDeser = null;
+   * This is a Map of Maps. The top-level Map is keyed by (Class)parentType, and the inner Maps are keyed by (QName)elementType.
+   */
+  private Map<Class<?>, Map<QName, Class<?>>> extensionTypeReg = new HashMap<>();
+  private ExtensionSerializer defaultSer = null;
+  private ExtensionDeserializer defaultDeser = null;
   /*
-    This is a Map of Maps. The top-level Map is keyed by (Class)parentType,
-    and the inner Maps are keyed by (QName)attrName.
-  */
-  protected Map extensionAttributeTypeReg = new Hashtable();
+   * This is a Map of Maps. The top-level Map is keyed by (Class)parentType, and the inner Maps are keyed by (QName)attrName.
+   */
+  private Map<Class<?>, Map<QName, Integer>> extensionAttributeTypeReg = new HashMap<>();
 
   /**
-   * Set the serializer to be used when none is found for an extensibility
-   * element. Set this to null to have an exception thrown when
-   * unexpected extensibility elements are encountered. Default value is
-   * an instance of UnknownExtensionSerializer.
+   * Set the serializer to be used when none is found for an extensibility element. Set this to null to have an exception thrown when unexpected extensibility elements are encountered. Default value is an instance of UnknownExtensionSerializer.
    *
    * @see UnknownExtensionSerializer
    */
-  public void setDefaultSerializer(ExtensionSerializer defaultSer)
-  {
+  public void setDefaultSerializer(ExtensionSerializer defaultSer) {
     this.defaultSer = defaultSer;
   }
 
   /**
-   * Get the serializer to be used when none is found for an extensibility
-   * element. Default value is an instance of UnknownExtensionSerializer.
+   * Get the serializer to be used when none is found for an extensibility element. Default value is an instance of UnknownExtensionSerializer.
    *
    * @see UnknownExtensionSerializer
    */
-  public ExtensionSerializer getDefaultSerializer()
-  {
+  public ExtensionSerializer getDefaultSerializer() {
     return defaultSer;
   }
 
   /**
-   * Set the deserializer to be used when none is found for an encountered
-   * element. Set this to null to have an exception thrown when
-   * unexpected extensibility elements are encountered. Default value is
-   * an instance of UnknownExtensionDeserializer.
+   * Set the deserializer to be used when none is found for an encountered element. Set this to null to have an exception thrown when unexpected extensibility elements are encountered. Default value is an instance of UnknownExtensionDeserializer.
    *
    * @see UnknownExtensionDeserializer
    */
-  public void setDefaultDeserializer(ExtensionDeserializer defaultDeser)
-  {
+  public void setDefaultDeserializer(ExtensionDeserializer defaultDeser) {
     this.defaultDeser = defaultDeser;
   }
 
   /**
-   * Get the deserializer to be used when none is found for an encountered
-   * element. Default value is an instance of UnknownExtensionDeserializer.
+   * Get the deserializer to be used when none is found for an encountered element. Default value is an instance of UnknownExtensionDeserializer.
    *
    * @see UnknownExtensionDeserializer
    */
-  public ExtensionDeserializer getDefaultDeserializer()
-  {
+  public ExtensionDeserializer getDefaultDeserializer() {
     return defaultDeser;
   }
 
   /**
-   * Declare that the specified serializer should be used to serialize
-   * all extensibility elements with a qname matching elementType, when
-   * encountered as children of the specified parentType.
+   * Declare that the specified serializer should be used to serialize all extensibility elements with a qname matching elementType, when encountered as children of the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * definition this extension was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this extensibility element was found in the list of
-   * extensibility elements belonging to a javax.wsdl.Binding.
-   * @param elementType the qname of the extensibility element
-   * @param es the extension serializer to use
+   * @param parentType
+   *          a class object indicating where in the WSDL definition this extension was encountered. For example, javax.wsdl.Binding.class would be used to indicate this extensibility element was found in the list of extensibility elements belonging to a javax.wsdl.Binding.
+   * @param elementType
+   *          the qname of the extensibility element
+   * @param es
+   *          the extension serializer to use
    *
    * @see #querySerializer(Class, QName)
    */
-  public void registerSerializer(Class parentType,
-                                 QName elementType,
-                                 ExtensionSerializer es)
-  {
-    Map innerSerializerReg = (Map)serializerReg.get(parentType);
-
-    if (innerSerializerReg == null)
-    {
-      innerSerializerReg = new Hashtable();
-
-      serializerReg.put(parentType, innerSerializerReg);
-    }
-
+  public void registerSerializer(Class<?> parentType, QName elementType, ExtensionSerializer es) {
+    Map<QName, ExtensionSerializer> innerSerializerReg = serializerReg.computeIfAbsent(parentType , key -> new HashMap<>());
     innerSerializerReg.put(elementType, es);
   }
 
   /**
-   * Declare that the specified deserializer should be used to deserialize
-   * all extensibility elements with a qname matching elementType, when
-   * encountered as immediate children of the element represented by the
-   * specified parentType.
+   * Declare that the specified deserializer should be used to deserialize all extensibility elements with a qname matching elementType, when encountered as immediate children of the element represented by the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * document this extensibility element was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this element was encountered as an immediate child of
-   * a &lt;wsdl:binding&gt; element.
-   * @param elementType the qname of the extensibility element
-   * @param ed the extension deserializer to use
+   * @param parentType
+   *          a class object indicating where in the WSDL document this extensibility element was encountered. For example, javax.wsdl.Binding.class would be used to indicate this element was encountered as an immediate child of a &lt;wsdl:binding&gt; element.
+   * @param elementType
+   *          the qname of the extensibility element
+   * @param ed
+   *          the extension deserializer to use
    *
    * @see #queryDeserializer(Class, QName)
    */
-  public void registerDeserializer(Class parentType,
-                                   QName elementType,
-                                   ExtensionDeserializer ed)
-  {
-    Map innerDeserializerReg = (Map)deserializerReg.get(parentType);
-
-    if (innerDeserializerReg == null)
-    {
-      innerDeserializerReg = new Hashtable();
-
-      deserializerReg.put(parentType, innerDeserializerReg);
-    }
-
+  public void registerDeserializer(Class<?> parentType, QName elementType, ExtensionDeserializer ed) {
+    Map<QName, ExtensionDeserializer> innerDeserializerReg = deserializerReg.computeIfAbsent(parentType, key -> new HashMap<>());
     innerDeserializerReg.put(elementType, ed);
   }
 
   /**
-   * Look up the serializer to use for the extensibility element with
-   * the qname elementType, which was encountered as a child of the
-   * specified parentType.
+   * Look up the serializer to use for the extensibility element with the qname elementType, which was encountered as a child of the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * definition this extension was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this extensibility element was found in the list of
-   * extensibility elements belonging to a javax.wsdl.Binding.
-   * @param elementType the qname of the extensibility element
+   * @param parentType
+   *          a class object indicating where in the WSDL definition this extension was encountered. For example, javax.wsdl.Binding.class would be used to indicate this extensibility element was found in the list of extensibility elements belonging to a javax.wsdl.Binding.
+   * @param elementType
+   *          the qname of the extensibility element
    *
-   * @return the extension serializer, if one was found. If none was
-   * found, the behavior depends on the value of the defaultSerializer
-   * property. If the defaultSerializer property is set to a non-null
-   * value, that value is returned; otherwise, a WSDLException is
-   * thrown.
+   * @return the extension serializer, if one was found. If none was found, the behavior depends on the value of the defaultSerializer property. If the defaultSerializer property is set to a non-null value, that value is returned; otherwise, a WSDLException is thrown.
    *
    * @see #registerSerializer(Class, QName, ExtensionSerializer)
    * @see #setDefaultSerializer(ExtensionSerializer)
    */
-  public ExtensionSerializer querySerializer(Class parentType,
-                                             QName elementType)
-                                               throws WSDLException
-  {
-    Map innerSerializerReg = (Map)serializerReg.get(parentType);
+  public ExtensionSerializer querySerializer(Class<?> parentType, QName elementType) throws WSDLException {
+    Map<QName, ExtensionSerializer> innerSerializerReg = serializerReg.get(parentType);
     ExtensionSerializer es = null;
 
-    if (innerSerializerReg != null)
-    {
-      es = (ExtensionSerializer)innerSerializerReg.get(elementType);
+    if (innerSerializerReg != null) {
+      es = innerSerializerReg.get(elementType);
     }
 
-    if (es == null)
-    {
+    if (es == null) {
       es = defaultSer;
     }
 
-    if (es == null)
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "No ExtensionSerializer found " +
-                              "to serialize a '" + elementType +
-                              "' element in the context of a '" +
-                              parentType.getName() + "'.");
+    if (es == null) {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionSerializer found " + "to serialize a '" + elementType + "' element in the context of a '" + parentType.getName() + "'.");
     }
 
     return es;
   }
 
   /**
-   * Look up the deserializer for the extensibility element with the
-   * qname elementType, which was encountered as an immediate child
-   * of the element represented by the specified parentType.
+   * Look up the deserializer for the extensibility element with the qname elementType, which was encountered as an immediate child of the element represented by the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * document this extensibility element was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this element was encountered as an immediate child of
-   * a &lt;wsdl:binding&gt; element.
-   * @param elementType the qname of the extensibility element
+   * @param parentType
+   *          a class object indicating where in the WSDL document this extensibility element was encountered. For example, javax.wsdl.Binding.class would be used to indicate this element was encountered as an immediate child of a &lt;wsdl:binding&gt; element.
+   * @param elementType
+   *          the qname of the extensibility element
    *
-   * @return the extension deserializer, if one was found. If none was
-   * found, the behavior depends on the value of the defaultDeserializer
-   * property. If the defaultDeserializer property is set to a non-null
-   * value, that value is returned; otherwise, a WSDLException is thrown.
+   * @return the extension deserializer, if one was found. If none was found, the behavior depends on the value of the defaultDeserializer property. If the defaultDeserializer property is set to a non-null value, that value is returned; otherwise, a WSDLException is thrown.
    *
    * @see #registerDeserializer(Class, QName, ExtensionDeserializer)
    * @see #setDefaultDeserializer(ExtensionDeserializer)
    */
-  public ExtensionDeserializer queryDeserializer(Class parentType,
-                                                 QName elementType)
-                                                   throws WSDLException
-  {
-    Map innerDeserializerReg = (Map)deserializerReg.get(parentType);
+  public ExtensionDeserializer queryDeserializer(Class<?> parentType, QName elementType) throws WSDLException {
+    Map<QName, ExtensionDeserializer> innerDeserializerReg = deserializerReg.get(parentType);
     ExtensionDeserializer ed = null;
 
-    if (innerDeserializerReg != null)
-    {
-      ed = (ExtensionDeserializer)innerDeserializerReg.get(elementType);
+    if (innerDeserializerReg != null) {
+      ed = innerDeserializerReg.get(elementType);
     }
 
-    if (ed == null)
-    {
+    if (ed == null) {
       ed = defaultDeser;
     }
 
-    if (ed == null)
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "No ExtensionDeserializer found " +
-                              "to deserialize a '" + elementType +
-                              "' element in the context of a '" +
-                              parentType.getName() + "'.");
+    if (ed == null) {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No ExtensionDeserializer found " + "to deserialize a '" + elementType + "' element in the context of a '" + parentType.getName() + "'.");
     }
 
     return ed;
   }
 
   /**
-   * Returns a set of QNames representing the extensibility elements
-   * that are allowed as children of the specified parent type.
-   * Basically, this method returns the keys associated with the set
-   * of extension deserializers registered for this parent type.
-   * Returns null if no extension deserializers are registered for
-   * this parent type.
+   * Returns a set of QNames representing the extensibility elements that are allowed as children of the specified parent type. Basically, this method returns the keys associated with the set of extension deserializers registered for this parent type. Returns null if no extension deserializers are
+   * registered for this parent type.
    */
-  public Set getAllowableExtensions(Class parentType)
-  {
-    Map innerDeserializerReg = (Map)deserializerReg.get(parentType);
+  public Set<QName> getAllowableExtensions(Class<?> parentType) {
+    Map<QName, ExtensionDeserializer> innerDeserializerReg = deserializerReg.get(parentType);
 
-    return (innerDeserializerReg != null)
-           ? innerDeserializerReg.keySet()
-           : null;
+    return (innerDeserializerReg != null) ? innerDeserializerReg.keySet() : null;
   }
 
   /**
-   * Declare that the specified extensionType is the concrete
-   * class which should be used to represent extensibility elements
-   * with qnames matching elementType, that are intended to exist as
-   * children of the specified parentType.
+   * Declare that the specified extensionType is the concrete class which should be used to represent extensibility elements with qnames matching elementType, that are intended to exist as children of the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * definition this extension would exist. For example,
-   * javax.wsdl.Binding.class would be used to indicate
-   * this extensibility element would be added to the list of
-   * extensibility elements belonging to a javax.wsdl.Binding,
-   * after being instantiated.
-   * @param elementType the qname of the extensibility element
-   * @param extensionType the concrete class which should be instantiated
+   * @param parentType
+   *          a class object indicating where in the WSDL definition this extension would exist. For example, javax.wsdl.Binding.class would be used to indicate this extensibility element would be added to the list of extensibility elements belonging to a javax.wsdl.Binding, after being
+   *          instantiated.
+   * @param elementType
+   *          the qname of the extensibility element
+   * @param extensionType
+   *          the concrete class which should be instantiated
    *
    * @see #createExtension(Class, QName)
    */
-  public void mapExtensionTypes(Class parentType,
-                                QName elementType,
-                                Class extensionType)
-  {
-    Map innerExtensionTypeReg = (Map)extensionTypeReg.get(parentType);
-
-    if (innerExtensionTypeReg == null)
-    {
-      innerExtensionTypeReg = new Hashtable();
-
-      extensionTypeReg.put(parentType, innerExtensionTypeReg);
-    }
-
+  public void mapExtensionTypes(Class<?> parentType, QName elementType, Class<?> extensionType) {
+    Map<QName, Class<?>> innerExtensionTypeReg = extensionTypeReg.computeIfAbsent(parentType, key -> new HashMap<>());
     innerExtensionTypeReg.put(elementType, extensionType);
   }
 
   /**
-   * Create an instance of the type which was declared to be used to
-   * represent extensibility elements with qnames matching elementType,
-   * when intended to exist as children of the specified parentType.
-   * This method allows a user to instantiate an extensibility element
-   * without having to know the implementing type.
+   * Create an instance of the type which was declared to be used to represent extensibility elements with qnames matching elementType, when intended to exist as children of the specified parentType. This method allows a user to instantiate an extensibility element without having to know the
+   * implementing type.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * definition this extension will exist. For example,
-   * javax.wsdl.Binding.class would be used to indicate
-   * this extensibility element is going to be added to the list of
-   * extensibility elements belonging to a javax.wsdl.Binding,
-   * after being instantiated.
-   * @param elementType the qname of the extensibility element
+   * @param parentType
+   *          a class object indicating where in the WSDL definition this extension will exist. For example, javax.wsdl.Binding.class would be used to indicate this extensibility element is going to be added to the list of extensibility elements belonging to a javax.wsdl.Binding, after being
+   *          instantiated.
+   * @param elementType
+   *          the qname of the extensibility element
    *
-   * @return a new instance of the type used to represent the
-   * specified extension
+   * @return a new instance of the type used to represent the specified extension
    *
    * @see #mapExtensionTypes(Class, QName, Class)
    */
-  public ExtensibilityElement createExtension(Class parentType,
-                                              QName elementType)
-                                                throws WSDLException
-  {
-    Map innerExtensionTypeReg = (Map)extensionTypeReg.get(parentType);
-    Class extensionType = null;
+  public ExtensibilityElement createExtension(Class<?> parentType, QName elementType) throws WSDLException {
+    Map<QName, Class<?>> innerExtensionTypeReg = extensionTypeReg.get(parentType);
+    Class<?> extensionType = null;
 
-    if (innerExtensionTypeReg != null)
-    {
-      extensionType = (Class)innerExtensionTypeReg.get(elementType);
+    if (innerExtensionTypeReg != null) {
+      extensionType = innerExtensionTypeReg.get(elementType);
     }
 
-    if (extensionType == null)
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "No Java extensionType found " +
-                              "to represent a '" + elementType +
-                              "' element in the context of a '" +
-                              parentType.getName() + "'.");
-    }
-    else if (!(ExtensibilityElement.class.isAssignableFrom(extensionType)))
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "The Java extensionType '" +
-                              extensionType.getName() + "' does " +
-                              "not implement the ExtensibilityElement " +
-                              "interface.");
+    if (extensionType == null) {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "No Java extensionType found " + "to represent a '" + elementType + "' element in the context of a '" + parentType.getName() + "'.");
+    } else if (!(ExtensibilityElement.class.isAssignableFrom(extensionType))) {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "The Java extensionType '" + extensionType.getName() + "' does " + "not implement the ExtensibilityElement " + "interface.");
     }
 
-    try
-    {
-      ExtensibilityElement ee = (ExtensibilityElement)extensionType.newInstance();
-      
-      if (ee.getElementType() == null)
-      {
+    try {
+      ExtensibilityElement ee = (ExtensibilityElement) extensionType.getDeclaredConstructor().newInstance();
+
+      if (ee.getElementType() == null) {
         ee.setElementType(elementType);
       }
-      
+
       return ee;
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       /*
-        Catches:
-                 InstantiationException
-                 IllegalAccessException
-      */
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "Problem instantiating Java " +
-                              "extensionType '" + extensionType.getName() +
-                              "'.",
-                              e);
+       * Catches: InstantiationException IllegalAccessException
+       */
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Problem instantiating Java " + "extensionType '" + extensionType.getName() + "'.", e);
     }
   }
 
   /**
-   * Declare that the type of the specified extension attribute, when it occurs
-   * as an attribute of the specified parent type, should be assumed to be
-   * attrType.
+   * Declare that the type of the specified extension attribute, when it occurs as an attribute of the specified parent type, should be assumed to be attrType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * document this extensibility attribute was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this attribute was defined on a &lt;wsdl:binding> element.
-   * @param attrName the qname of the extensibility attribute
-   * @param attrType one of the constants defined on the AttributeExtensible
-   * class
+   * @param parentType
+   *          a class object indicating where in the WSDL document this extensibility attribute was encountered. For example, javax.wsdl.Binding.class would be used to indicate this attribute was defined on a &lt;wsdl:binding> element.
+   * @param attrName
+   *          the qname of the extensibility attribute
+   * @param attrType
+   *          one of the constants defined on the AttributeExtensible class
    *
    * @see #queryExtensionAttributeType(Class, QName)
    * @see AttributeExtensible
    */
-  public void registerExtensionAttributeType(Class parentType,
-                                             QName attrName,
-                                             int attrType)
-  {
-    Map innerExtensionAttributeTypeReg =
-      (Map)extensionAttributeTypeReg.get(parentType);
-
-    if (innerExtensionAttributeTypeReg == null)
-    {
-      innerExtensionAttributeTypeReg = new Hashtable();
-
-      extensionAttributeTypeReg.put(parentType, innerExtensionAttributeTypeReg);
-    }
-
-    innerExtensionAttributeTypeReg.put(attrName, new Integer(attrType));
+  public void registerExtensionAttributeType(Class<?> parentType, QName attrName, int attrType) {
+    Map<QName, Integer> innerExtensionAttributeTypeReg = extensionAttributeTypeReg.computeIfAbsent(parentType, key -> new HashMap<>());
+    innerExtensionAttributeTypeReg.put(attrName, Integer.valueOf(attrType));
   }
 
   /**
-   * Look up the type of the extensibility attribute with the qname attrName,
-   * which was defined on an element represented by the specified parentType.
+   * Look up the type of the extensibility attribute with the qname attrName, which was defined on an element represented by the specified parentType.
    *
-   * @param parentType a class object indicating where in the WSDL
-   * document this extensibility attribute was encountered. For
-   * example, javax.wsdl.Binding.class would be used to indicate
-   * this attribute was defined on a &lt;wsdl:binding> element.
-   * @param attrName the qname of the extensibility attribute
+   * @param parentType
+   *          a class object indicating where in the WSDL document this extensibility attribute was encountered. For example, javax.wsdl.Binding.class would be used to indicate this attribute was defined on a &lt;wsdl:binding> element.
+   * @param attrName
+   *          the qname of the extensibility attribute
    *
    * @return one of the constants defined on the AttributeExtensible class
    *
    * @see #registerExtensionAttributeType(Class, QName, int)
    * @see AttributeExtensible
    */
-  public int queryExtensionAttributeType(Class parentType, QName attrName)
-  {
-    Map innerExtensionAttributeTypeReg =
-      (Map)extensionAttributeTypeReg.get(parentType);
+  public int queryExtensionAttributeType(Class<?> parentType, QName attrName) {
+    Map<QName, Integer> innerExtensionAttributeTypeReg = extensionAttributeTypeReg.get(parentType);
     Integer attrType = null;
 
-    if (innerExtensionAttributeTypeReg != null)
-    {
-      attrType = (Integer)innerExtensionAttributeTypeReg.get(attrName);
+    if (innerExtensionAttributeTypeReg != null) {
+      attrType = innerExtensionAttributeTypeReg.get(attrName);
     }
 
-    if (attrType != null)
-    {
+    if (attrType != null) {
       return attrType.intValue();
-    }
-    else
-    {
+    } else {
       return AttributeExtensible.NO_DECLARED_TYPE;
     }
   }

--- a/src/main/java/javax/wsdl/extensions/ExtensionSerializer.java
+++ b/src/main/java/javax/wsdl/extensions/ExtensionSerializer.java
@@ -32,7 +32,7 @@ public interface ExtensionSerializer
    * encountered in
    * @param extReg the ExtensionRegistry to use (if needed again)
    */
-  void marshall(Class parentType,
+  void marshall(Class<?> parentType,
                 QName elementType,
                 ExtensibilityElement extension,
                 PrintWriter pw,

--- a/src/main/java/javax/wsdl/extensions/UnknownExtensibilityElement.java
+++ b/src/main/java/javax/wsdl/extensions/UnknownExtensibilityElement.java
@@ -85,7 +85,7 @@ public class UnknownExtensibilityElement implements ExtensibilityElement,
 
   public String toString()
   {
-    StringBuffer strBuf = new StringBuffer();
+    StringBuilder strBuf = new StringBuilder();
 
     strBuf.append("UnknownExtensibilityElement (" + elementType + "):");
     strBuf.append("\nrequired=" + required);

--- a/src/main/java/javax/wsdl/extensions/UnknownExtensionDeserializer.java
+++ b/src/main/java/javax/wsdl/extensions/UnknownExtensionDeserializer.java
@@ -24,7 +24,7 @@ public class UnknownExtensionDeserializer implements ExtensionDeserializer,
 {
   public static final long serialVersionUID = 1;
 
-  public ExtensibilityElement unmarshall(Class parentType,
+  public ExtensibilityElement unmarshall(Class<?> parentType,
                                          QName elementType,
                                          Element el,
                                          Definition def,
@@ -40,7 +40,7 @@ public class UnknownExtensionDeserializer implements ExtensionDeserializer,
 
     if (requiredStr != null)
     {
-      unknownExt.setRequired(new Boolean(requiredStr));
+      unknownExt.setRequired(Boolean.valueOf(requiredStr));
     }
 
     unknownExt.setElement(el);

--- a/src/main/java/javax/wsdl/extensions/UnknownExtensionSerializer.java
+++ b/src/main/java/javax/wsdl/extensions/UnknownExtensionSerializer.java
@@ -23,7 +23,7 @@ public class UnknownExtensionSerializer implements ExtensionSerializer,
 {
   public static final long serialVersionUID = 1;
 
-  public void marshall(Class parentType,
+  public void marshall(Class<?> parentType,
                        QName elementType,
                        ExtensibilityElement extension,
                        PrintWriter pw,

--- a/src/main/java/javax/wsdl/extensions/mime/MIMEMultipartRelated.java
+++ b/src/main/java/javax/wsdl/extensions/mime/MIMEMultipartRelated.java
@@ -31,5 +31,5 @@ public interface MIMEMultipartRelated extends ExtensibilityElement,
   /**
    * Get all the MIME parts defined here.
    */
-  List getMIMEParts();
+  List<MIMEPart> getMIMEParts();
 }

--- a/src/main/java/javax/wsdl/extensions/schema/Schema.java
+++ b/src/main/java/javax/wsdl/extensions/schema/Schema.java
@@ -31,7 +31,7 @@ public interface Schema extends ExtensibilityElement, Serializable
      *
      * @return a map of lists of schema imports
      */
-    Map getImports();
+    Map<String, List<SchemaImport>> getImports();
     
     /**
      * Create a new schema import
@@ -53,7 +53,7 @@ public interface Schema extends ExtensibilityElement, Serializable
      * 
      * @return a list of schema references.
      */
-    List getIncludes();
+    List<SchemaReference> getIncludes();
     
     /**
      * Create a new schema reference to represent an include.
@@ -75,7 +75,7 @@ public interface Schema extends ExtensibilityElement, Serializable
      * 
      * @return a list of schema references.
      */
-    List getRedefines();
+    List<SchemaReference> getRedefines();
     
     /**
      * Create a new schema reference to represent a redefine.

--- a/src/main/java/javax/wsdl/extensions/schema/SchemaReference.java
+++ b/src/main/java/javax/wsdl/extensions/schema/SchemaReference.java
@@ -7,8 +7,6 @@ package javax.wsdl.extensions.schema;
 
 import java.io.Serializable;
 
-import javax.wsdl.extensions.schema.Schema;
-
 /**
  * Represents an include or a redefine element within a schema element.
  * 

--- a/src/main/java/javax/wsdl/extensions/soap/SOAPFault.java
+++ b/src/main/java/javax/wsdl/extensions/soap/SOAPFault.java
@@ -41,12 +41,12 @@ public interface SOAPFault extends ExtensibilityElement, java.io.Serializable
    *
    * @param encodingStyles the desired encodingStyles
    */
-  void setEncodingStyles(List encodingStyles);
+  void setEncodingStyles(List<String> encodingStyles);
 
   /**
    * Get the encodingStyles for this SOAP fault.
    */
-  List getEncodingStyles();
+  List<String> getEncodingStyles();
 
   /**
    * Set the namespace URI for this SOAP fault.

--- a/src/main/java/javax/wsdl/extensions/soap/SOAPHeader.java
+++ b/src/main/java/javax/wsdl/extensions/soap/SOAPHeader.java
@@ -54,12 +54,12 @@ public interface SOAPHeader extends ExtensibilityElement, java.io.Serializable
    *
    * @param encodingStyles the desired encodingStyles
    */
-  void setEncodingStyles(List encodingStyles);
+  void setEncodingStyles(List<String> encodingStyles);
 
   /**
    * Get the encodingStyles for this SOAP header.
    */
-  List getEncodingStyles();
+  List<String> getEncodingStyles();
 
   /**
    * Set the namespace URI for this SOAP header.
@@ -93,5 +93,5 @@ public interface SOAPHeader extends ExtensibilityElement, java.io.Serializable
    * 
    * @return a list of all SOAP header faults contained in this SOAP header.
    */
-  List getSOAPHeaderFaults();
+  List<SOAPHeaderFault> getSOAPHeaderFaults();
 }

--- a/src/main/java/javax/wsdl/extensions/soap/SOAPHeaderFault.java
+++ b/src/main/java/javax/wsdl/extensions/soap/SOAPHeaderFault.java
@@ -55,12 +55,12 @@ public interface SOAPHeaderFault extends ExtensibilityElement,
    *
    * @param encodingStyles the desired encodingStyles
    */
-  void setEncodingStyles(List encodingStyles);
+  void setEncodingStyles(List<String> encodingStyles);
 
   /**
    * Get the encodingStyles for this SOAP header fault.
    */
-  List getEncodingStyles();
+  List<String> getEncodingStyles();
 
   /**
    * Set the namespace URI for this SOAP header fault.

--- a/src/main/java/javax/wsdl/factory/WSDLFactory.java
+++ b/src/main/java/javax/wsdl/factory/WSDLFactory.java
@@ -13,144 +13,85 @@ import javax.wsdl.extensions.*;
 import javax.wsdl.xml.*;
 
 /**
- * This abstract class defines a factory API that enables applications
- * to obtain a WSDLFactory capable of producing new Definitions, new
- * WSDLReaders, and new WSDLWriters.
+ * This abstract class defines a factory API that enables applications to obtain a WSDLFactory capable of producing new Definitions, new WSDLReaders, and new WSDLWriters.
  * 
- * Some ideas used here have been shamelessly copied from the
- * wonderful JAXP and Xerces work.
+ * Some ideas used here have been shamelessly copied from the wonderful JAXP and Xerces work.
  *
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public abstract class WSDLFactory
-{
-  private static final String PROPERTY_NAME =
-    "javax.wsdl.factory.WSDLFactory";
-  private static final String PROPERTY_FILE_NAME =
-    "wsdl.properties";
-  private static final String META_INF_SERVICES_PROPERTY_FILE_NAME =
-    "javax.wsdl.factory.WSDLFactory";
-  private static final String DEFAULT_FACTORY_IMPL_NAME =
-    "com.ibm.wsdl.factory.WSDLFactoryImpl";  
+public abstract class WSDLFactory {
+  private static final String PROPERTY_NAME = "javax.wsdl.factory.WSDLFactory";
+  private static final String PROPERTY_FILE_NAME = "wsdl.properties";
+  private static final String META_INF_SERVICES_PROPERTY_FILE_NAME = "javax.wsdl.factory.WSDLFactory";
+  private static final String DEFAULT_FACTORY_IMPL_NAME = "com.ibm.wsdl.factory.WSDLFactoryImpl";
 
   private static String fullPropertyFileName = null;
   private static String metaInfServicesFullPropertyFileName = null;
 
   /**
-   * Get a new instance of a WSDLFactory. This method
-   * follows (almost) the same basic sequence of steps that JAXP
-   * follows to determine the fully-qualified class name of the
-   * class which implements WSDLFactory. 
+   * Get a new instance of a WSDLFactory. This method follows (almost) the same basic sequence of steps that JAXP follows to determine the fully-qualified class name of the class which implements WSDLFactory.
    * <p>
    * The steps in order are:
    * <ol>
-   *  <li>Check the property file META-INF/services/javax.wsdl.factory.WSDLFactory.</li>
-   *  <li>Check the javax.wsdl.factory.WSDLFactory system property.</li>
-   *  <li>Check the lib/wsdl.properties file in the JRE directory. The key
-   *  will have the same name as the above system property.</li>
-   *  <li>Use the default class name provided by the implementation.</li>
+   * <li>Check the property file META-INF/services/javax.wsdl.factory.WSDLFactory.</li>
+   * <li>Check the javax.wsdl.factory.WSDLFactory system property.</li>
+   * <li>Check the lib/wsdl.properties file in the JRE directory. The key will have the same name as the above system property.</li>
+   * <li>Use the default class name provided by the implementation.</li>
    * </ol>
    * <p>
-   * Once an instance of a WSDLFactory is obtained, invoke
-   * newDefinition(), newWSDLReader(), or newWSDLWriter(), to create
-   * the desired instances.
+   * Once an instance of a WSDLFactory is obtained, invoke newDefinition(), newWSDLReader(), or newWSDLWriter(), to create the desired instances.
    */
-  public static WSDLFactory newInstance() throws WSDLException
-  {
+  public static WSDLFactory newInstance() throws WSDLException {
     String factoryImplName = findFactoryImplName();
 
     return newInstance(factoryImplName);
   }
 
   /**
-   * Get a new instance of a WSDLFactory. This method
-   * returns an instance of the class factoryImplName.
-   * Once an instance of a WSDLFactory is obtained, invoke
-   * newDefinition(), newWSDLReader(), or newWSDLWriter(), to create
-   * the desired instances.
+   * Get a new instance of a WSDLFactory. This method returns an instance of the class factoryImplName. Once an instance of a WSDLFactory is obtained, invoke newDefinition(), newWSDLReader(), or newWSDLWriter(), to create the desired instances.
    *
-   * @param factoryImplName the fully-qualified class name of the
-   * class which provides a concrete implementation of the abstract
-   * class WSDLFactory.
+   * @param factoryImplName
+   *          the fully-qualified class name of the class which provides a concrete implementation of the abstract class WSDLFactory.
    */
-  public static WSDLFactory newInstance(String factoryImplName)
-    throws WSDLException
-  {
-    if (factoryImplName != null)
-    {
-      try
-      {
-        Class cl = Class.forName(factoryImplName);
-  
-        return (WSDLFactory)cl.newInstance();
-      }
-      catch (Exception e)
-      {
+  public static WSDLFactory newInstance(String factoryImplName) throws WSDLException {
+    if (factoryImplName != null) {
+      try {
+        Class<?> cl = Class.forName(factoryImplName);
+
+        return (WSDLFactory) cl.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
         /*
-          Catches:
-                   ClassNotFoundException
-                   InstantiationException
-                   IllegalAccessException
-        */
-        throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                "Problem instantiating factory " +
-                                "implementation.",
-                                e);
+         * Catches: ClassNotFoundException InstantiationException IllegalAccessException
+         */
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Problem instantiating factory implementation.", e);
       }
-    }
-    else
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "Unable to find name of factory " +
-                              "implementation.");
+    } else {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Unable to find name of factory implementation.");
     }
   }
 
   /**
-   * Get a new instance of a WSDLFactory. This method
-   * returns an instance of the class factoryImplName, using
-   * the specified ClassLoader.
-   * Once an instance of a WSDLFactory is obtained, invoke
-   * newDefinition(), newWSDLReader(), or newWSDLWriter(), to create
-   * the desired instances.
+   * Get a new instance of a WSDLFactory. This method returns an instance of the class factoryImplName, using the specified ClassLoader. Once an instance of a WSDLFactory is obtained, invoke newDefinition(), newWSDLReader(), or newWSDLWriter(), to create the desired instances.
    *
-   * @param factoryImplName the fully-qualified class name of the
-   * class which provides a concrete implementation of the abstract
-   * class WSDLFactory.
-   * @param classLoader the ClassLoader to use to load the WSDLFactory
-   * implementation.
+   * @param factoryImplName
+   *          the fully-qualified class name of the class which provides a concrete implementation of the abstract class WSDLFactory.
+   * @param classLoader
+   *          the ClassLoader to use to load the WSDLFactory implementation.
    */
-  public static WSDLFactory newInstance(String factoryImplName,
-                                        ClassLoader classLoader)
-    throws WSDLException
-  {
-    if (factoryImplName != null)
-    {
-      try
-      {
-        Class cl = classLoader.loadClass(factoryImplName);
+  public static WSDLFactory newInstance(String factoryImplName, ClassLoader classLoader) throws WSDLException {
+    if (factoryImplName != null) {
+      try {
+        Class<?> cl = classLoader.loadClass(factoryImplName);
 
-        return (WSDLFactory)cl.newInstance();
-      }
-      catch (Exception e)
-      {
+        return (WSDLFactory) cl.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
         /*
-          Catches:
-                   ClassNotFoundException
-                   InstantiationException
-                   IllegalAccessException
-        */
-        throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                                "Problem instantiating factory " +
-                                "implementation.",
-                                e);
+         * Catches: ClassNotFoundException InstantiationException IllegalAccessException
+         */
+        throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Problem instantiating factory " + "implementation.", e);
       }
-    }
-    else
-    {
-      throw new WSDLException(WSDLException.CONFIGURATION_ERROR,
-                              "Unable to find name of factory " +
-                              "implementation.");
+    } else {
+      throw new WSDLException(WSDLException.CONFIGURATION_ERROR, "Unable to find name of factory " + "implementation.");
     }
   }
 
@@ -170,120 +111,86 @@ public abstract class WSDLFactory
   public abstract WSDLWriter newWSDLWriter();
 
   /**
-   * Create a new instance of an ExtensionRegistry with pre-registered
-   * serializers/deserializers for the SOAP, HTTP and MIME
-   * extensions. Java extensionTypes are also mapped for all
-   * the SOAP, HTTP and MIME extensions.
+   * Create a new instance of an ExtensionRegistry with pre-registered serializers/deserializers for the SOAP, HTTP and MIME extensions. Java extensionTypes are also mapped for all the SOAP, HTTP and MIME extensions.
    */
   public abstract ExtensionRegistry newPopulatedExtensionRegistry();
 
-  private static String findFactoryImplName()
-  {
+  private static PrivilegedAction<InputStream> getMetaInfServicesAsStream(String fileName) {
+    return (() -> WSDLFactory.class.getResourceAsStream(fileName));
+  }
+
+  private static String findFactoryImplName() {
     String factoryImplName = null;
 
     // First, check the META-INF/services property file.
     final String metaInfServicesPropFileName = getMetaInfFullPropertyFileName();
 
-    if (metaInfServicesPropFileName != null)
-    {
-      try
-      {
-        InputStream is = (InputStream) AccessController.doPrivileged(
-            new PrivilegedAction() {
-                public Object run() {
-                  return WSDLFactory.class.getResourceAsStream(metaInfServicesPropFileName);
-                }
-            });
-        
-        if(is != null)
-        {
-          InputStreamReader isr = new InputStreamReader(is);
-          BufferedReader br = new BufferedReader(isr);
-          
-          factoryImplName = br.readLine();
-          
-          br.close();
-          isr.close();
-          is.close();
-        }
+    try (InputStream is = AccessController.doPrivileged(getMetaInfServicesAsStream(metaInfServicesPropFileName))) {
 
-        if (factoryImplName != null)
-        {
-          return factoryImplName;
-        }
+      if (is != null) {
+        InputStreamReader isr = new InputStreamReader(is);
+        BufferedReader br = new BufferedReader(isr);
+
+        factoryImplName = br.readLine();
+
+        br.close();
+        isr.close();
       }
-      catch (IOException e)
-      {
+
+      if (factoryImplName != null) {
+        return factoryImplName;
       }
+    } catch (IOException e) {
+      factoryImplName = null;
     }
 
     // Second, check the system property.
-    try
-    {
+    try {
       factoryImplName = System.getProperty(PROPERTY_NAME);
 
-      if (factoryImplName != null)
-      {
+      if (factoryImplName != null) {
         return factoryImplName;
       }
-    }
-    catch (SecurityException e)
-    {
+    } catch (SecurityException e) {
+      factoryImplName = null;
     }
 
     // Third, check the properties file.
     String propFileName = getFullPropertyFileName();
 
-    if (propFileName != null)
-    {
-      try
-      {
+    if (propFileName != null) {
+      try (FileInputStream fis = new FileInputStream(new File(propFileName))) {
         Properties properties = new Properties();
-        File propFile = new File(propFileName);
-        FileInputStream fis = new FileInputStream(propFile);
-
         properties.load(fis);
-        fis.close();
-
         factoryImplName = properties.getProperty(PROPERTY_NAME);
 
-        if (factoryImplName != null)
-        {
+        if (factoryImplName != null) {
           return factoryImplName;
         }
-      }
-      catch (IOException e)
-      {
+      } catch (IOException e) {
+        factoryImplName = null;
       }
     }
-    
+
     // Fourth, return the default.
     return DEFAULT_FACTORY_IMPL_NAME;
   }
 
-  private static String getFullPropertyFileName()
-  {
-    if (fullPropertyFileName == null)
-    {
-      try
-      {
+  private static String getFullPropertyFileName() {
+    if (fullPropertyFileName == null) {
+      try {
         String javaHome = System.getProperty("java.home");
 
-        fullPropertyFileName = javaHome + File.separator + "lib" +
-                               File.separator + PROPERTY_FILE_NAME;
-      }
-      catch (SecurityException e)
-      {
+        fullPropertyFileName = javaHome + File.separator + "lib" + File.separator + PROPERTY_FILE_NAME;
+      } catch (SecurityException e) {
       }
     }
 
     return fullPropertyFileName;
   }
-  
-  private static String getMetaInfFullPropertyFileName()
-  {
-    if (metaInfServicesFullPropertyFileName == null)
-    {
+
+  private static String getMetaInfFullPropertyFileName() {
+    if (metaInfServicesFullPropertyFileName == null) {
       String metaInfServices = "/META-INF/services/";
       metaInfServicesFullPropertyFileName = metaInfServices + META_INF_SERVICES_PROPERTY_FILE_NAME;
     }

--- a/src/main/java/javax/xml/namespace/QName.java
+++ b/src/main/java/javax/xml/namespace/QName.java
@@ -7,30 +7,25 @@ package javax.xml.namespace;
 import java.io.*;
 
 /**
- * <code>QName</code> class represents the value of a qualified name
- * as specified in <a href="http://www.w3.org/TR/xmlschema-2/#QName">XML
- * Schema Part2: Datatypes specification</a>.
+ * <code>QName</code> class represents the value of a qualified name as specified in <a href="http://www.w3.org/TR/xmlschema-2/#QName">XML Schema Part2: Datatypes specification</a>.
  * <p>
- * The value of a QName contains a <b>namespaceURI</b> and a <b>localPart</b>.
- * The localPart provides the local part of the qualified name. The
- * namespaceURI is a URI reference identifying the namespace.
+ * The value of a QName contains a <b>namespaceURI</b> and a <b>localPart</b>. The localPart provides the local part of the qualified name. The namespaceURI is a URI reference identifying the namespace.
  *
  * Note: Some of this impl code was taken from Axis.
  *
  * @author axis-dev
  * @author Matthew J. Duftler (duftler@us.ibm.com)
  */
-public class QName implements Serializable
-{
+public class QName implements Serializable {
   // Comment/shared empty string.
-  private static final String emptyString = "";
+  private static final String EMPTY_STRING = "";
 
   // Field namespaceURI.
   private String namespaceURI;
 
   // Field localPart.
   private String localPart;
-  
+
   // Field prefix.
   private String prefix;
 
@@ -39,61 +34,51 @@ public class QName implements Serializable
   /**
    * Constructor for the QName.
    *
-   * @param localPart Local part of the QName
+   * @param localPart
+   *          Local part of the QName
    */
-  public QName(String localPart)
-  {
-    this.namespaceURI = emptyString;
-    this.localPart    = (localPart == null)
-                        ? emptyString
-                        : localPart.intern();
-    this.prefix       = emptyString;
+  public QName(String localPart) {
+    this.namespaceURI = EMPTY_STRING;
+    this.localPart = (localPart == null) ? EMPTY_STRING : localPart.intern();
+    this.prefix = EMPTY_STRING;
   }
 
   /**
    * Constructor for the QName.
    *
-   * @param namespaceURI Namespace URI for the QName
-   * @param localPart Local part of the QName.
+   * @param namespaceURI
+   *          Namespace URI for the QName
+   * @param localPart
+   *          Local part of the QName.
    */
-  public QName(String namespaceURI, String localPart)
-  {
-    this.namespaceURI = (namespaceURI == null)
-                        ? emptyString
-                        : namespaceURI.intern();
-    this.localPart    = (localPart == null)
-                        ? emptyString
-                        : localPart.intern();
-    this.prefix       = emptyString;
+  public QName(String namespaceURI, String localPart) {
+    this.namespaceURI = (namespaceURI == null) ? EMPTY_STRING : namespaceURI.intern();
+    this.localPart = (localPart == null) ? EMPTY_STRING : localPart.intern();
+    this.prefix = EMPTY_STRING;
   }
 
   /**
    * Constructor for the QName.
    *
-   * @param namespaceURI Namespace URI for the QName
-   * @param localPart Local part of the QName.
-   * @param prefix the xmlns-declared prefix for this namespaceURI
+   * @param namespaceURI
+   *          Namespace URI for the QName
+   * @param localPart
+   *          Local part of the QName.
+   * @param prefix
+   *          the xmlns-declared prefix for this namespaceURI
    */
-  public QName(String namespaceURI, String localPart, String prefix)
-  {
-    this.namespaceURI = (namespaceURI == null)
-                        ? emptyString
-                        : namespaceURI.intern();
-    this.localPart    = (localPart == null)
-                        ? emptyString
-                        : localPart.intern();
-    this.prefix       = (prefix == null)
-                        ? emptyString
-                        : prefix.intern();
+  public QName(String namespaceURI, String localPart, String prefix) {
+    this.namespaceURI = (namespaceURI == null) ? EMPTY_STRING : namespaceURI.intern();
+    this.localPart = (localPart == null) ? EMPTY_STRING : localPart.intern();
+    this.prefix = (prefix == null) ? EMPTY_STRING : prefix.intern();
   }
-  
+
   /**
    * Gets the Namespace URI for this QName
    *
    * @return Namespace URI
    */
-  public String getNamespaceURI()
-  {
+  public String getNamespaceURI() {
     return namespaceURI;
   }
 
@@ -102,19 +87,17 @@ public class QName implements Serializable
    *
    * @return Local part
    */
-  public String getLocalPart()
-  {
+  public String getLocalPart() {
     return localPart;
   }
-  
+
   /**
    * Gets the prefix for this QName
    * 
    * @return prefix of this QName
    */
-  public String getPrefix()
-  {
-      return prefix;
+  public String getPrefix() {
+    return prefix;
   }
 
   /**
@@ -122,126 +105,92 @@ public class QName implements Serializable
    *
    * @return a string representation of the QName
    */
-  public String toString()
-  {
-    return ((namespaceURI == emptyString)
-            ? localPart
-            : '{' + namespaceURI + '}' + localPart);
+  public String toString() {
+    return (EMPTY_STRING.equals(namespaceURI) || namespaceURI == null ? localPart : '{' + namespaceURI + '}' + localPart);
   }
 
   /**
    * Tests this QName for equality with another object.
    * <p>
-   * If the given object is not a QName or is null then this method
-   * returns <tt>false</tt>.
+   * If the given object is not a QName or is null then this method returns <tt>false</tt>.
    * <p>
-   * For two QNames to be considered equal requires that both
-   * localPart and namespaceURI must be equal. This method uses
-   * <code>String.equals</code> to check equality of localPart
-   * and namespaceURI. Any class that extends QName is required
-   * to satisfy this equality contract.
+   * For two QNames to be considered equal requires that both localPart and namespaceURI must be equal. This method uses <code>String.equals</code> to check equality of localPart and namespaceURI. Any class that extends QName is required to satisfy this equality contract.
    * <p>
    * This method satisfies the general contract of the <code>Object.equals</code> method.
    *
-   * @param obj the reference object with which to compare
+   * @param obj
+   *          the reference object with which to compare
    *
-   * @return <code>true</code> if the given object is identical to this
-   *      QName: <code>false</code> otherwise.
+   * @return <code>true</code> if the given object is identical to this QName: <code>false</code> otherwise.
    */
-  public final boolean equals(Object obj)
-  {
-    if (obj == this)
-    {
+  public final boolean equals(Object obj) {
+    if (obj == this) {
       return true;
     }
 
-    if (!(obj instanceof QName))
-    {
+    if (!(obj instanceof QName)) {
       return false;
     }
 
-    return (namespaceURI == ((QName) obj).namespaceURI)
-            && (localPart == ((QName) obj).localPart);
+    return (namespaceURI == ((QName) obj).namespaceURI) && (localPart == ((QName) obj).localPart);
 
   }
 
   /**
    * Returns a QName holding the value of the specified String.
    * <p>
-   * The string must be in the form returned by the QName.toString()
-   * method, i.e. "{namespaceURI}localPart", with the "{namespaceURI}"
-   * part being optional.
+   * The string must be in the form returned by the QName.toString() method, i.e. "{namespaceURI}localPart", with the "{namespaceURI}" part being optional.
    * <p>
-   * This method doesn't do a full validation of the resulting QName.
-   * In particular, it doesn't check that the resulting namespace URI
-   * is a legal URI (per RFC 2396 and RFC 2732), nor that the resulting
-   * local part is a legal NCName per the XML Namespaces specification.
+   * This method doesn't do a full validation of the resulting QName. In particular, it doesn't check that the resulting namespace URI is a legal URI (per RFC 2396 and RFC 2732), nor that the resulting local part is a legal NCName per the XML Namespaces specification.
    *
-   * @param s the string to be parsed
-   * @throws IllegalArgumentException If the specified String
-   * cannot be parsed as a QName
+   * @param s
+   *          the string to be parsed
+   * @throws IllegalArgumentException
+   *           If the specified String cannot be parsed as a QName
    * @return QName corresponding to the given String
    */
-  public static QName valueOf(String s)
-  {
-    if ((s == null) || s.equals(""))
-    {
+  public static QName valueOf(String s) {
+    if ((s == null) || s.equals("")) {
       throw new IllegalArgumentException("Invalid QName literal.");
     }
 
-    if (s.charAt(0) == '{')
-    {
+    if (s.charAt(0) == '{') {
       int i = s.indexOf('}');
 
-      if (i == -1)
-      {
+      if (i == -1) {
         throw new IllegalArgumentException("Invalid QName literal.");
       }
 
-      if (i == s.length() - 1)
-      {
+      if (i == s.length() - 1) {
         throw new IllegalArgumentException("Invalid QName literal.");
-      }
-      else
-      {
+      } else {
         return new QName(s.substring(1, i), s.substring(i + 1));
       }
-    }
-    else
-    {
+    } else {
       return new QName(s);
     }
   }
 
   /**
-   * Returns a hash code value for this QName object. The hash code
-   * is based on both the localPart and namespaceURI parts of the
-   * QName. This method satisfies the  general contract of the
-   * <code>Object.hashCode</code> method.
+   * Returns a hash code value for this QName object. The hash code is based on both the localPart and namespaceURI parts of the QName. This method satisfies the general contract of the <code>Object.hashCode</code> method.
    *
    * @return a hash code value for this Qname object
    */
-  public final int hashCode()
-  {
+  public final int hashCode() {
     return namespaceURI.hashCode() ^ localPart.hashCode();
   }
 
-  private void readObject(ObjectInputStream in) throws IOException,
-                                                       ClassNotFoundException
-  {
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
 
     namespaceURI = namespaceURI.intern();
-    localPart    = localPart.intern();
-    if(prefix == null)
-    {
-        //The serialized object did not have a 'prefix'.
-        //i.e. it was serialized from an old version of QName.
-        prefix = emptyString;
-    }
-    else
-    {
-        prefix = prefix.intern();
+    localPart = localPart.intern();
+    if (prefix == null) {
+      // The serialized object did not have a 'prefix'.
+      // i.e. it was serialized from an old version of QName.
+      prefix = EMPTY_STRING;
+    } else {
+      prefix = prefix.intern();
     }
   }
 }


### PR DESCRIPTION
* Remove raw types and use generic ones
* Replace `Vector` with `ArrayList` (synchronized -> unsynchronized)
* Replace `StringBuffer` with `StringBuilder` (synchronized -> unsynchronized)
* Add private constructor to utility classes
* Remove some useless `throws WSDLException` when the method does not throw any.
* Change pom to 1.7.0 as it might involve some breaking changes due to the use of `List` instead of `Vector`