### PR TITLE
Restore schema serializers to match 1.6.3 behavior (Fixes #11)

### DIFF
--- a/src/main/java/com/ibm/wsdl/extensions/PopulatedExtensionRegistry.java
+++ b/src/main/java/com/ibm/wsdl/extensions/PopulatedExtensionRegistry.java
@@ -408,11 +408,6 @@ public class PopulatedExtensionRegistry extends ExtensionRegistry
                       MIMEConstants.Q_ELEM_MIME_MIME_XML,
                       MIMEMimeXmlImpl.class);
 
-    // [tellef - 2019-02-22]: The following code has been removed
-    //  to prevent WSDL4j from fetching external files using HTTP.
-    //
-    //Register the schema parser
-    /*
     mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
         SchemaImpl.class);
     registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
@@ -433,6 +428,5 @@ public class PopulatedExtensionRegistry extends ExtensionRegistry
         new SchemaDeserializer());
     registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
         new SchemaSerializer());
-    */
   }
 }


### PR DESCRIPTION
This PR restores the previously available schema serializers that were present in version 1.6.3 of libre-wsdl4j. These serializers were removed in a [2019-02-22] change (commented out by Tellef) to prevent WSDL4J from fetching external files over HTTP.

However, in 1.6.3, this functionality worked as expected, and the serializers were registered without issues. Since the rationale for removing this behavior isn't fully clear and there have been no further changes or comments explaining it, this PR reintroduces the original behavior to ensure libre-wsdl4j can act as a drop-in replacement.

If fetching external resources is a concern, we could explore bundling required schema files with the distribution to avoid network dependency. But for now, restoring this logic ensures compatibility and ease of replacement.