### PR TITLE
Add system property to control external schema serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ https://opensource.org/licenses/cpl1.0.php
    "WSDL, that's an anchronym i haven't heard in almost ten years."  
    "Still big in the enterprise world" - comments on the Internet. 
 
+## Configuration
+
+### `libre-wsdl4j.externalSchemaSerializers.enabled` (default: `true`)
+
+Controls whether support for external schema serializers and deserializers is enabled.
+
+When set to `true` (the default), the library registers serializers and deserializers for XML Schema definitions (XSD) based on various W3C versions (1999, 2000, 2001). This allows for parsing and generating schema extensions in WSDL documents.
+
+To **disable** this behavior (e.g., to reduce overhead, improve startup time, or in Internet restricted environments), set the system property to `false`:
+
+```
+-Dlibre-wsdl4j.externalSchemaSerializers.enabled=false
+```
+
+When disabled, schema extensions in WSDL documents (for example via Apache CXF) will not be automatically serialized or deserialized.
 
 ## Maintainer  ##
 * [@andreasrosdal](https://github.com/andreasrosdal) - Andreas Røsdal

--- a/src/main/java/com/ibm/wsdl/extensions/PopulatedExtensionRegistry.java
+++ b/src/main/java/com/ibm/wsdl/extensions/PopulatedExtensionRegistry.java
@@ -408,25 +408,27 @@ public class PopulatedExtensionRegistry extends ExtensionRegistry
                       MIMEConstants.Q_ELEM_MIME_MIME_XML,
                       MIMEMimeXmlImpl.class);
 
-    mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
-        SchemaImpl.class);
-    registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
-        new SchemaDeserializer());
-    registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
-        new SchemaSerializer());
+    if ("true".equals(System.getProperty("libre-wsdl4j.externalSchemaSerializers.enabled", "true"))) {
+      mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
+          SchemaImpl.class);
+      registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
+          new SchemaDeserializer());
+      registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_1999,
+          new SchemaSerializer());
 
-    mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
-        SchemaImpl.class);
-    registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
-        new SchemaDeserializer());
-    registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
-        new SchemaSerializer());
+      mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
+          SchemaImpl.class);
+      registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
+          new SchemaDeserializer());
+      registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_2000,
+          new SchemaSerializer());
 
-    mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
-        SchemaImpl.class);
-    registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
-        new SchemaDeserializer());
-    registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
-        new SchemaSerializer());
+      mapExtensionTypes(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
+          SchemaImpl.class);
+      registerDeserializer(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
+          new SchemaDeserializer());
+      registerSerializer(Types.class, SchemaConstants.Q_ELEM_XSD_2001,
+          new SchemaSerializer());
+    }
   }
 }


### PR DESCRIPTION
Introduced `libre-wsdl4j.externalSchemaSerializers.enabled` (default: true)  to allow enabling or disabling registration of external XSD serializers  and deserializers. The default is set to `true` to ensure compatibility  with existing use cases, such as Apache CXF, where these serializers  are expected to be present. 

This makes `libre-wsdl4j` a drop-in replacement for WSDL4J in most setups.  Users who do not require schema extension support (likely a minority) can explicitly disable it to reduce overhead or avoid conflicts.




